### PR TITLE
transaction.py fixes

### DIFF
--- a/pyrevitlib/pyrevit/revit/db/transaction.py
+++ b/pyrevitlib/pyrevit/revit/db/transaction.py
@@ -77,8 +77,9 @@ class Transaction():
                 self._rvtxn.Commit()
             except Exception as errmsg:
                 self._rvtxn.RollBack()
-                mlogger.error('Error in Transaction Commit. '
-                              'Rolling back changes. | %s', errmsg)
+                if self._logerror:
+                    mlogger.error('Error in Transaction Commit. '
+                                  'Rolling back changes. | %s', errmsg)
         self._rvtxn.Dispose()
 
     @property
@@ -137,8 +138,9 @@ class TransactionGroup():
                     self._rvtxn_grp.Commit()
             except Exception as errmsg:
                 self._rvtxn_grp.RollBack()
-                mlogger.error('Error in TransactionGroup Commit: rolled back.')
-                mlogger.error('Error: %s', errmsg)
+                if self._logerror:
+                    mlogger.error('Error in TransactionGroup Commit. '
+                                  'Rolling back changes. | %s', errmsg)
         self._rvtxn_grp.Dispose()
 
     @property


### PR DESCRIPTION
See https://github.com/pyrevitlabs/pyRevit/issues/2300

This PR checks for `log_errors=True` before logging ANY error messages (instead of only context errors).

I also modified the log message for `TransactionGroup` to match the others within this file.