### PR TITLE
Update EventHandling.cs

### DIFF
--- a/pyrevitlib/pyrevit/runtime/EventHandling.cs
+++ b/pyrevitlib/pyrevit/runtime/EventHandling.cs
@@ -277,7 +277,7 @@ namespace PyRevitLabs.PyRevit.Runtime {
         private static void ActivateUpdaterListener() {
             if (updaterListener == null) {
                 updaterListener = new UpdaterListener();
-                UpdaterRegistry.RegisterUpdater(updaterListener);
+                UpdaterRegistry.RegisterUpdater(updaterListener, true);
                 UpdaterRegistry.AddTrigger(
                     updaterListener.GetUpdaterId(),
                     new ElementCategoryFilter(BuiltInCategory.INVALID, inverted: true),


### PR DESCRIPTION
Added flag for isOptional in [RegisterUpdater()](https://apidocs.co/apps/revit/2024/edffd44c-2511-c9ee-f330-5cd77414d0e9.htm) to remove warning when updater not found.

![image](https://github.com/user-attachments/assets/d5673d92-92b6-4618-a398-fbeffd08a838)

This will not remove the warning from models that already show it, but new models will not display this error when opened without the pyRevit updater hook.