### PR TITLE
Fix workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,12 @@ updates:
       # Check for npm updates on Sundays
       day: "sunday"
     # Raise pull requests for version updates
-    # to pip against the `develop-4` branch
-    target-branch: "develop-4"
+    # to pip against the `develop` branch
+    target-branch: "develop"
   - package-ecosystem: "gomod"
     # directory required https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#vendor
     directory: "/"
-    target-branch: "develop-4"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     # Set update schedule for GitHub Actions
@@ -21,4 +21,4 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "monthly"
-    target-branch: "develop-4"
+    target-branch: "develop"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,8 @@ on:
   # when PRs from forked repos are merged
   push:
     branches:
-      - develop-4
       - develop
-   paths:
+    paths:
       - 'bin/**'
       - 'dev/**'
       - 'extensions/**'


### PR DESCRIPTION
Remind me to never use the web IDE to do merge conflict resolution...

The main workflow was not running because a wrong indentation in the yaml file.

I also replaced all the `develop-4` references (mostly in dependabot) and set them to `develop` instead.