### PR TITLE
build: fix function that uses utils.system function

### DIFF
--- a/dev/_changelog.py
+++ b/dev/_changelog.py
@@ -208,7 +208,7 @@ def _header(text: str, level: int = 2):
 
 def _find_latest_tag():
     # get the latest tag
-    latest_tag = utils.system(
+    latest_tag, _ = utils.system(
         [
             "git",
             "for-each-ref",
@@ -223,7 +223,7 @@ def _find_latest_tag():
 
 def _find_previous_tag():
     # get the latest tag
-    last_three_tags = utils.system(
+    last_three_tags, _ = utils.system(
         [
             "git",
             "for-each-ref",
@@ -243,7 +243,7 @@ def _find_previous_tag():
 
 
 def _collect_changes(tag: str, fetch_info: bool = True):
-    gitlog_report = utils.system(
+    gitlog_report, _ = utils.system(
         ["git", "log", "--pretty=format:%h %s%n%b%n/", f"{tag}..HEAD"]
     )
     return _find_changes(gitlog_report, fetch_info=fetch_info)

--- a/dev/_misc.py
+++ b/dev/_misc.py
@@ -18,7 +18,7 @@ def count_sloc(_: Dict[str, str]):
         "modules",
     ]
     counter_args.extend(configs.SOURCE_DIRS)
-    report = utils.system(counter_args)
+    report, _ = utils.system(counter_args)
     print(report)
 
 

--- a/dev/_release.py
+++ b/dev/_release.py
@@ -205,7 +205,7 @@ def setup_certificate(_: Dict[str, str]):
 
 
 def _sign_binary(filepath: str, cert_name: str, cert_fingerprint: str):
-    res = utils.system(
+    res, _ = utils.system(
         [
             install.get_tool("signtool"),
             "sign",
@@ -256,7 +256,7 @@ def sign_binaries(_: Dict[str, str]):
 
 
 def _ensure_clean_tree():
-    res = utils.system(["git", "status"])
+    res, _ = utils.system(["git", "status"])
     if "nothing to commit" not in res:
         print("You have uncommited changes in working tree. Commit those first")
         sys.exit(1)

--- a/dev/_telem.py
+++ b/dev/_telem.py
@@ -45,7 +45,7 @@ def build_telem(args: Dict[str, str]):
 
     print("Updating telemetry server dependencies...")
     go_tool = install.get_tool("go")
-    report = utils.system(
+    utils.system(
         [go_tool, "get", r"./..."],
         cwd=op.abspath(configs.TELEMETRYSERVERPATH),
         dump_stdout=True
@@ -58,7 +58,7 @@ def build_telem(args: Dict[str, str]):
         if "<output>" in args
         else op.abspath(configs.TELEMETRYSERVERBIN)
     )
-    report = utils.system(
+    utils.system(
         [go_tool, "build", "-o", output_bin, op.abspath(configs.TELEMETRYSERVER)],
         cwd=op.abspath(configs.TELEMETRYSERVERPATH),
     )


### PR DESCRIPTION
`system.utils` return variable was changed when trying to make the CI/CD work for netcore, but not every calls to that function were adjusted properly.

Whit this changes the "Notify Issue Threads (WIP)" step of the CI should pass without errors