### PR TITLE
WIP: use ILRepack for single dll builds

### DIFF
--- a/dev/pyRevitLabs.PyRevit.Runtime/Directory.Build.targets
+++ b/dev/pyRevitLabs.PyRevit.Runtime/Directory.Build.targets
@@ -41,7 +41,7 @@
         <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.1" />
     </ItemGroup>
 
-    <Target Name="ILRepack" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+    <Target Name="ILRepack" AfterTargets="AfterBuild" Condition="'$(Configuration)' == 'Release'">
         <ItemGroup>
             <InputAssemblies Include="$(TargetPath)"/>
             <InputAssemblies Include="$(TargetDir)*.dll" Exclude="$(TargetPath)"/>
@@ -63,7 +63,7 @@
             TargetKind="SameAsPrimaryAssembly" />
     </Target>
 
-    <Target Name="Deploy" AfterTargets="AfterBuild">
+    <Target Name="Deploy" AfterTargets="ILRepack">
         <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(DeployDestinationFiles)"/>
         <Message Importance="high" Text="$(MSBuildProjectName) -> Copy to $([System.IO.Path]::GetFullPath('$(DeployDestinationFiles)'))" />
     </Target>

--- a/dev/pyRevitLabs.PyRevit.Runtime/Directory.Build.targets
+++ b/dev/pyRevitLabs.PyRevit.Runtime/Directory.Build.targets
@@ -44,7 +44,7 @@
     <Target Name="ILRepack" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
         <ItemGroup>
             <InputAssemblies Include="$(TargetPath)"/>
-            <InputAssemblies Include="$(OutputPath)*.dll" Exclude="$(TargetPath)"/>
+            <InputAssemblies Include="$(TargetDir)*.dll" Exclude="$(TargetPath)"/>
         </ItemGroup>
 
         <ItemGroup>

--- a/dev/pyRevitLabs.PyRevit.Runtime/Directory.Build.targets
+++ b/dev/pyRevitLabs.PyRevit.Runtime/Directory.Build.targets
@@ -35,11 +35,32 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="docopt.net" Version="0.8.1" />
         <PackageReference Include="AirspaceFixer" Version="1.0.6" />
         <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NetCoreApp'"  Include="ControlzEx" Version="4.4.0" />
         <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"  Include="ControlzEx" Version="3.0.2.4" />
+        <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.1" />
     </ItemGroup>
+
+    <Target Name="ILRepack" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+        <ItemGroup>
+            <InputAssemblies Include="$(TargetPath)"/>
+            <InputAssemblies Include="$(OutputPath)*.dll" Exclude="$(TargetPath)"/>
+        </ItemGroup>
+
+        <ItemGroup>
+            <DoNotInternalizeAssemblies Include="Revit" />
+        </ItemGroup>
+
+        <ILRepack
+            AllowDuplicateResources="false"
+            DebugInfo="true"
+            Internalize="true"
+            InputAssemblies="@(InputAssemblies)"
+            InternalizeExclude="@(DoNotInternalizeAssemblies)"
+            OutputFile="$(TargetPath)"
+            Parallel="true"
+            TargetKind="SameAsPrimaryAssembly" />
+    </Target>
 
     <Target Name="Deploy" AfterTargets="AfterBuild">
         <Copy SourceFiles="$(TargetPath)" DestinationFiles="$(DeployDestinationFiles)"/>

--- a/dev/pyRevitLabs.PyRevit.Runtime/Directory.Build.targets
+++ b/dev/pyRevitLabs.PyRevit.Runtime/Directory.Build.targets
@@ -48,7 +48,7 @@
         </ItemGroup>
 
         <ItemGroup>
-            <DoNotInternalizeAssemblies Include="Revit" />
+            <DoNotInternalizeAssemblies Include="^Autodesk.*" />
         </ItemGroup>
 
         <ILRepack
@@ -59,6 +59,7 @@
             InternalizeExclude="@(DoNotInternalizeAssemblies)"
             OutputFile="$(TargetPath)"
             Parallel="true"
+            LibraryPath="$(RevitDevDir)\$(RevitVersion)"
             TargetKind="SameAsPrimaryAssembly" />
     </Target>
 

--- a/dev/pyRevitLabs.PyRevit.Runtime/EventHandling.cs
+++ b/dev/pyRevitLabs.PyRevit.Runtime/EventHandling.cs
@@ -23,7 +23,8 @@ using Xceed.Wpf.AvalonDock.Controls;
 using pyRevitLabs.NLog;
 using pyRevitLabs.PyRevit;
 
-namespace PyRevitLabs.PyRevit.Runtime {
+namespace PyRevitLabs.PyRevit.Runtime
+{
     public enum EventType {
         // Autodesk.Revit.ApplicationServices.Application Events
         Application_ApplicationInitialized,

--- a/dev/pyRevitLabs.PyRevit.Runtime/ScriptCommands.cs
+++ b/dev/pyRevitLabs.PyRevit.Runtime/ScriptCommands.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows.Input;
-using System.Windows.Controls;
 
 using Autodesk.Revit.UI;
 using Autodesk.Revit.DB;
@@ -12,7 +11,8 @@ using Autodesk.Revit.Attributes;
 using MenuItem = System.Windows.Controls.MenuItem;
 using ContextMenu = System.Windows.Controls.ContextMenu;
 
-namespace PyRevitLabs.PyRevit.Runtime {
+namespace PyRevitLabs.PyRevit.Runtime
+{
     public class CommandTypeExecConfigs {
         // unlike fullframe or clean engine modes, the config script mode is determined at
         // script execution by using a shortcut key combination. This parameter is created to

--- a/dev/pyRevitLabs.PyRevit.Runtime/ScriptConsole.cs
+++ b/dev/pyRevitLabs.PyRevit.Runtime/ScriptConsole.cs
@@ -10,12 +10,12 @@ using System.Windows.Threading;
 using Autodesk.Revit.UI;
 using System.Text.RegularExpressions;
 using System.Diagnostics;
-
 using pyRevitLabs.Common;
 using pyRevitLabs.CommonWPF.Controls;
 using pyRevitLabs.Emojis;
 
-namespace PyRevitLabs.PyRevit.Runtime {
+namespace PyRevitLabs.PyRevit.Runtime
+{
     public struct ScriptConsoleDebugger {
         public string Name;
         public Regex PromptFinder;

--- a/dev/pyRevitLabs.PyRevit.Runtime/telemetry.cs
+++ b/dev/pyRevitLabs.PyRevit.Runtime/telemetry.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.IO;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
-using System.Threading.Tasks;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.ApplicationServices;
 
@@ -13,7 +11,8 @@ using pyRevitLabs.Json;
 using pyRevitLabs.Common;
 using pyRevitLabs.TargetApps.Revit;
 
-namespace PyRevitLabs.PyRevit.Runtime {
+namespace PyRevitLabs.PyRevit.Runtime
+{
     public class TelemetryRecord {
         // schema
         public Dictionary<string, string> meta { get; private set; }

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIAppCmds.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIAppCmds.cs
@@ -1,26 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using System.Drawing;
 using System.Diagnostics;
-
+using System.Drawing;
+using System.IO;
 using pyRevitLabs.Common;
-using pyRevitLabs.CommonCLI;
 using pyRevitLabs.Common.Extensions;
-using pyRevitLabs.TargetApps.Revit;
-using pyRevitLabs.PyRevit;
-using pyRevitLabs.Language.Properties;
-
-using pyRevitLabs.NLog;
 using pyRevitLabs.Json;
 using pyRevitLabs.Json.Serialization;
-
+using pyRevitLabs.Language.Properties;
+using pyRevitLabs.NLog;
+using pyRevitLabs.PyRevit;
+using pyRevitLabs.TargetApps.Revit;
 using Console = Colorful.Console;
 
-namespace pyRevitCLI {
+namespace pyRevitCLI
+{
     public enum TargetCacheType {
         PyRevitCache,
         BIM360Cache

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLICloneCmds.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLICloneCmds.cs
@@ -1,26 +1,14 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using System.Drawing;
-using System.Diagnostics;
-
+using System.Linq;
 using pyRevitLabs.Common;
-using pyRevitLabs.CommonCLI;
-using pyRevitLabs.Common.Extensions;
-using pyRevitLabs.TargetApps.Revit;
-using pyRevitLabs.PyRevit;
-using pyRevitLabs.Language.Properties;
-
 using pyRevitLabs.NLog;
-using pyRevitLabs.Json;
-using pyRevitLabs.Json.Serialization;
-
+using pyRevitLabs.PyRevit;
+using pyRevitLabs.TargetApps.Revit;
 using Console = Colorful.Console;
 
-namespace pyRevitCLI {
+namespace pyRevitCLI
+{
     internal static class PyRevitCLICloneCmds {
         static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIExtensionCmds.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIExtensionCmds.cs
@@ -1,26 +1,13 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using System.Drawing;
 using System.Diagnostics;
-
+using System.Linq;
 using pyRevitLabs.Common;
-using pyRevitLabs.CommonCLI;
-using pyRevitLabs.Common.Extensions;
-using pyRevitLabs.TargetApps.Revit;
-using pyRevitLabs.PyRevit;
-using pyRevitLabs.Language.Properties;
-
 using pyRevitLabs.NLog;
-using pyRevitLabs.Json;
-using pyRevitLabs.Json.Serialization;
-
+using pyRevitLabs.PyRevit;
 using Console = Colorful.Console;
 
-namespace pyRevitCLI {
+namespace pyRevitCLI
+{
     internal static class PyRevitCLIExtensionCmds {
         static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIReleaseCmds.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIReleaseCmds.cs
@@ -1,26 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using System.Drawing;
-using System.Diagnostics;
-
+using System.Linq;
 using pyRevitLabs.Common;
-using pyRevitLabs.CommonCLI;
 using pyRevitLabs.Common.Extensions;
-using pyRevitLabs.TargetApps.Revit;
-using pyRevitLabs.PyRevit;
-using pyRevitLabs.Language.Properties;
-
 using pyRevitLabs.NLog;
-using pyRevitLabs.Json;
-using pyRevitLabs.Json.Serialization;
-
+using pyRevitLabs.PyRevit;
 using Console = Colorful.Console;
 
-namespace pyRevitCLI {
+namespace pyRevitCLI
+{
     internal static class PyRevitCLIReleaseCmds {
         static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIRevitCmds.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIRevitCmds.cs
@@ -1,26 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using System.Drawing;
-using System.Diagnostics;
-
 using pyRevitLabs.Common;
-using pyRevitLabs.CommonCLI;
 using pyRevitLabs.Common.Extensions;
-using pyRevitLabs.TargetApps.Revit;
-using pyRevitLabs.PyRevit;
-using pyRevitLabs.Language.Properties;
-
-using pyRevitLabs.NLog;
 using pyRevitLabs.Json;
-using pyRevitLabs.Json.Serialization;
-
+using pyRevitLabs.NLog;
+using pyRevitLabs.PyRevit;
+using pyRevitLabs.TargetApps.Revit;
 using Console = Colorful.Console;
 
-namespace pyRevitCLI {
+namespace pyRevitCLI
+{
     internal static class PyRevitCLIRevitCmds {
         static Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/dev/pyRevitLabs/pyRevitCLI/pyRevitCLI.csproj
+++ b/dev/pyRevitLabs/pyRevitCLI/pyRevitCLI.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.8.1" />
     <PackageReference Include="Colorful.Console" Version="1.2.15" />
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,4 +31,30 @@
     <ProjectReference Include="..\pyRevitLabs.pyRevit\pyRevitLabs.PyRevit.csproj" />
     <ProjectReference Include="..\pyRevitLabs.TargetApps.Revit\pyRevitLabs.TargetApps.Revit.csproj" />
   </ItemGroup>
+
+  <Target Name="Log" AfterTargets="Build">
+
+  </Target>
+
+  <Target Name="ILRepack" AfterTargets="AfterBuild" Condition="'$(Configuration)' == 'Release'">
+    <ItemGroup>
+      <InputAssemblies Include="$(TargetPath)"/>
+      <InputAssemblies Include="$(TargetDir)*.dll" Exclude="$(TargetPath)"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <DoNotInternalizeAssemblies Include="^Autodesk.*" />
+    </ItemGroup>
+
+    <ILRepack
+        AllowDuplicateResources="false"
+        DebugInfo="true"
+        Internalize="true"
+        InputAssemblies="@(InputAssemblies)"
+        InternalizeExclude="@(DoNotInternalizeAssemblies)"
+        OutputFile="$(TargetPath)"
+        Parallel="true"
+        LibraryPath="$(RevitDevDir)\$(RevitVersion)"
+        TargetKind="SameAsPrimaryAssembly" />
+  </Target>
 </Project>

--- a/dev/pyRevitLabs/pyRevitCLI/pyRevitCLI.csproj
+++ b/dev/pyRevitLabs/pyRevitCLI/pyRevitCLI.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\pyRevitLabs.Common\pyRevitLabs.Common.csproj" />
-    <ProjectReference Include="..\pyRevitLabs.CommonCLI\pyRevitLabs.CommonCLI.csproj" />
     <ProjectReference Include="..\pyRevitLabs.Language\pyRevitLabs.Language.csproj" />
     <ProjectReference Include="..\pyRevitLabs.pyRevit\pyRevitLabs.PyRevit.csproj" />
     <ProjectReference Include="..\pyRevitLabs.TargetApps.Revit\pyRevitLabs.TargetApps.Revit.csproj" />

--- a/dev/pyRevitLabs/pyRevitDoctor/Program.cs
+++ b/dev/pyRevitLabs/pyRevitDoctor/Program.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 
 using pyRevitDoctor.Properties;
 
-namespace pyRevitDoctor {
+namespace pyRevitDoctor
+{
     class Program {
         const string helpMessage = @"Fix potential or real problems
 

--- a/dev/pyRevitLabs/pyRevitLabs.Common/CodeCompiler.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/CodeCompiler.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using CS = Microsoft.CodeAnalysis.CSharp;
@@ -12,7 +11,8 @@ using VB = Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.Emit;
 
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     public static class CodeCompiler {
         #region CSharp Compilation
 

--- a/dev/pyRevitLabs/pyRevitLabs.Common/CommonUtils.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/CommonUtils.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 using pyRevitLabs.NLog;
-using System.Threading;
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     public static class CommonUtils {
         // private static object ProgressLock = new object();
         // private static int lastReport;

--- a/dev/pyRevitLabs/pyRevitLabs.Common/Consts.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/Consts.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     public class PyRevitLabsConsts {
         // product
         public const string ProductName = "pyRevit";

--- a/dev/pyRevitLabs/pyRevitLabs.Common/Errors.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/Errors.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     // ERROR CODES ===================================================================================================
     // error codes are to be used for non-critical, non-breaking errors
 

--- a/dev/pyRevitLabs/pyRevitLabs.Common/Extensions/Extensions.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/Extensions/Extensions.cs
@@ -1,19 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using System.Globalization;
 using System.CodeDom.Compiler;
 using System.CodeDom;
-using System.Web;
 
 using pyRevitLabs.NLog;
 using pyRevitLabs.Json;
 
-namespace pyRevitLabs.Common.Extensions {
+namespace pyRevitLabs.Common.Extensions
+{
     public static class CharExtensions {
         /// <summary>
         /// Remaps international characters to ascii compatible ones

--- a/dev/pyRevitLabs/pyRevitLabs.Common/GitInstaller.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/GitInstaller.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using LibGit2Sharp;
 using pyRevitLabs.NLog;
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     // git exceptions
     public class pyRevitInvalidGitCloneException : PyRevitException {
         public pyRevitInvalidGitCloneException() { }

--- a/dev/pyRevitLabs/pyRevitLabs.Common/Github.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/Github.cs
@@ -1,18 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
-
-using pyRevitLabs.Common;
 using pyRevitLabs.Common.Extensions;
 
 using pyRevitLabs.NLog;
 using pyRevitLabs.Json;
 using pyRevitLabs.Json.Linq;
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     public enum GithubReleaseAssetType {
         Unknown,
         Archive,

--- a/dev/pyRevitLabs/pyRevitLabs.Common/JSONDataSource.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/JSONDataSource.cs
@@ -1,19 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Net;
-using System.Text.RegularExpressions;
-
-using pyRevitLabs.Common;
-using pyRevitLabs.Common.Extensions;
 
 using pyRevitLabs.NLog;
 using pyRevitLabs.Json;
-using pyRevitLabs.Json.Linq;
 
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     public class JSONDataSource<T> {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/dev/pyRevitLabs/pyRevitLabs.Common/OSVersionInfo.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/OSVersionInfo.cs
@@ -1,16 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Security.Principal;
-using System.IO;
 
-using DotNetVersionFinder;
-using System.Security.AccessControl;
-
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     // https://code.msdn.microsoft.com/windowsapps/How-to-determine-the-263b1850
     public class OSVersionInfo {
 

--- a/dev/pyRevitLabs/pyRevitLabs.Common/Security/UserAuth.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/Security/UserAuth.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Principal;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Security.Principal;
 
-namespace pyRevitLabs.Common.Security {
+namespace pyRevitLabs.Common.Security
+{
     // access qualifiers
     public static class UserAuth {
         public static bool UserIsInSecurityGroup(string targetSid) {

--- a/dev/pyRevitLabs/pyRevitLabs.Common/UserEnv.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/UserEnv.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management;
 using System.Security.Principal;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Security.AccessControl;
 
 using DotNetVersionFinder;
 using pyRevitLabs.NLog;
@@ -16,7 +12,8 @@ using pyRevitLabs.NLog;
 
 // user default folder implementation from https://stackoverflow.com/a/21953690/2350244
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
 
     /// <summary>
     /// Standard folders registered with the system. These folders are installed with Windows Vista

--- a/dev/pyRevitLabs/pyRevitLabs.Common/UserSecurity.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/UserSecurity.cs
@@ -1,16 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Security.Principal;
+﻿using System.Security.Principal;
 using System.IO;
-
-using DotNetVersionFinder;
 using System.Security.AccessControl;
 
-namespace pyRevitLabs.Common {
+namespace pyRevitLabs.Common
+{
     // https://stackoverflow.com/a/22020271
     public class UserSecurity {
         WindowsIdentity _currentUser;

--- a/dev/pyRevitLabs/pyRevitLabs.CommonCLI/ConsoleProvider.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.CommonCLI/ConsoleProvider.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace pyRevitLabs.CommonCLI
 {

--- a/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Controls/ActivityBar.xaml.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Controls/ActivityBar.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -7,7 +6,8 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 
-namespace pyRevitLabs.CommonWPF.Controls {
+namespace pyRevitLabs.CommonWPF.Controls
+{
     /// <summary>
     /// Interaction logic for ActivityBar.xaml
     /// </summary>

--- a/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Controls/InputBar.xaml.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Controls/InputBar.xaml.cs
@@ -1,20 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
-namespace pyRevitLabs.CommonWPF.Controls {
+namespace pyRevitLabs.CommonWPF.Controls
+{
     /// <summary>
     /// Interaction logic for InputDebugBar.xaml
     /// </summary>

--- a/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Controls/LabelledTextBox.xaml.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Controls/LabelledTextBox.xaml.cs
@@ -1,17 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace pyRevitLabs.CommonWPF.Controls
 {

--- a/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Controls/SpinnerDotCircle.xaml.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Controls/SpinnerDotCircle.xaml.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Windows;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace pyRevitLabs.CommonWPF.Controls
 {
-	/// <summary>
-	/// Interaction logic for ucSpinnerDotCircle.xaml
-	/// </summary>
-	public partial class SpinnerDotCircle : UserControl
+    /// <summary>
+    /// Interaction logic for ucSpinnerDotCircle.xaml
+    /// </summary>
+    public partial class SpinnerDotCircle : UserControl
 	{
 		public SpinnerDotCircle()
 		{

--- a/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Windows/AppWindow.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.CommonWPF/Windows/AppWindow.cs
@@ -6,13 +6,12 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.ComponentModel;
 using System.Windows.Data;
-using System.Xaml;
 
 // packages
-using pyRevitLabs.MahAppsMetro;
 using pyRevitLabs.MahAppsMetro.Controls;
 
-namespace pyRevitLabs.CommonWPF.Windows {
+namespace pyRevitLabs.CommonWPF.Windows
+{
     /// <summary>
     /// Interaction logic for AppWindow.xaml
     /// </summary>

--- a/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataBase.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataBase.cs
@@ -6,10 +6,6 @@ using pyRevitLabs.Common;
 using pyRevitLabs.NLog.Targets;
 using pyRevitLabs.NLog.Config;
 
-#if DEBUG
-using pyRevitLabs.CommonCLI;
-#endif
-
 using pyRevitLabs.NLog;
 
 
@@ -125,7 +121,8 @@ using pyRevitLabs.NLog;
  */
 
 
-namespace pyRevitLabs.DeffrelDB {
+namespace pyRevitLabs.DeffrelDB
+{
     public enum ConnectionLockType {
         DataStore,
         DB,

--- a/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataFormatter.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataFormatter.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
-namespace pyRevitLabs.DeffrelDB {
+namespace pyRevitLabs.DeffrelDB
+{
     // data formatter
     public enum EntryChangeType {
         Insert,

--- a/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataFunctions.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataFunctions.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace pyRevitLabs.DeffrelDB {
+namespace pyRevitLabs.DeffrelDB
+{
     internal static class DataFunctions {
         // dstore
         public static void CreateDataStore(DataStore dstore) {

--- a/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataStore.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataStore.cs
@@ -4,14 +4,13 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 using pyRevitLabs.Common;
 
 using pyRevitLabs.NLog;
 
-namespace pyRevitLabs.DeffrelDB {
+namespace pyRevitLabs.DeffrelDB
+{
     // datastore
     public class DataStoreType {
         public readonly string TypeName = "txt";

--- a/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataTypes.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/DataTypes.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace pyRevitLabs.DeffrelDB {
+namespace pyRevitLabs.DeffrelDB
+{
     // database
     public sealed class DatabaseDefinition {
         public DatabaseDefinition() { }

--- a/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/Exceptions.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/Exceptions.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace pyRevitLabs.DeffrelDB {
+namespace pyRevitLabs.DeffrelDB
+{
     public class DeffrelDBException : Exception {
         public DeffrelDBException() { }
 

--- a/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/pyRevitLabs.DeffrelDB.csproj
+++ b/dev/pyRevitLabs/pyRevitLabs.DeffrelDB/pyRevitLabs.DeffrelDB.csproj
@@ -10,6 +10,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\pyRevitLabs.Common\pyRevitLabs.Common.csproj" />
-    <ProjectReference Include="..\pyRevitLabs.CommonCLI\pyRevitLabs.CommonCLI.csproj" />
   </ItemGroup>
 </Project>

--- a/dev/pyRevitLabs/pyRevitLabs.Emojis/Emojis.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Emojis/Emojis.cs
@@ -6,9 +6,9 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Reflection;
-using System.Resources;
 
-namespace pyRevitLabs.Emojis {
+namespace pyRevitLabs.Emojis
+{
     public static class Emojis {
         private static ZipArchive _emojiZip = null;
         private static ImageConverter _converter = new ImageConverter();

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit.Runtime.Shared/ExecParams.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit.Runtime.Shared/ExecParams.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace pyRevitLabs.PyRevit.Runtime.Shared
 {
     public class ExecParams

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/Controls/PyRevitWindow.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/Controls/PyRevitWindow.cs
@@ -1,7 +1,7 @@
 ﻿using System.Windows;
-using System.Windows.Controls;
 
-namespace pyRevitLabs.PyRevit.Controls {
+namespace pyRevitLabs.PyRevit.Controls
+{
     public class PyRevitWindow : Window {
         static PyRevitWindow(){
             DefaultStyleKeyProperty.OverrideMetadata(typeof(PyRevitWindow), new FrameworkPropertyMetadata(typeof(PyRevitWindow)));

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitAttachment.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitAttachment.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Security.AccessControl;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using pyRevitLabs.Common;
 using pyRevitLabs.TargetApps.Revit;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public enum PyRevitAttachmentType {
         AllUsers,
         CurrentUser

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitAttachments.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitAttachments.cs
@@ -1,21 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Text.RegularExpressions;
-using System.Security.Principal;
-using System.Text;
 using System.Linq;
 
 using pyRevitLabs.Common;
-using pyRevitLabs.Common.Extensions;
-
-using MadMilkman.Ini;
-using pyRevitLabs.Json.Linq;
 using pyRevitLabs.NLog;
 using pyRevitLabs.TargetApps.Revit;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public static class PyRevitAttachments {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
         

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitBundle.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitBundle.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace pyRevitLabs.PyRevit {
+﻿namespace pyRevitLabs.PyRevit
+{
     public enum PyRevitBundleTypes {
         Unknown,
         Tab,

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitCaches.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitCaches.cs
@@ -1,20 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
+﻿using System.IO;
 using System.Text.RegularExpressions;
-using System.Security.Principal;
-using System.Text;
 
 using pyRevitLabs.Common;
-using pyRevitLabs.Common.Extensions;
-
-using MadMilkman.Ini;
-using pyRevitLabs.Json.Linq;
 using pyRevitLabs.NLog;
 using pyRevitLabs.TargetApps.Revit;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public static class PyRevitCaches {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClone.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClone.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Linq;
 using System.Reflection;
-
+using System.Text.RegularExpressions;
+using Nett;
 using pyRevitLabs.Common;
 using pyRevitLabs.Common.Extensions;
-using pyRevitLabs.TargetApps.Revit;
-
-using Nett;
 using pyRevitLabs.NLog;
+using pyRevitLabs.TargetApps.Revit;
 
 namespace pyRevitLabs.PyRevit
 {

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClones.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClones.cs
@@ -2,18 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Text.RegularExpressions;
-using System.Security.Principal;
-using System.Text;
 
 using pyRevitLabs.Common;
 using pyRevitLabs.Common.Extensions;
-
-using MadMilkman.Ini;
-using pyRevitLabs.Json.Linq;
 using pyRevitLabs.NLog;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public class pyRevitInvalidPyRevitCloneException : pyRevitInvalidGitCloneException {
         public pyRevitInvalidPyRevitCloneException() { }
 

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitConfigs.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitConfigs.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Security.Principal;
-using System.Security.AccessControl;
 
 using pyRevitLabs.Common;
 using pyRevitLabs.NLog;

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitConsts.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitConsts.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Media;
@@ -6,7 +5,8 @@ using System.Windows.Media;
 using pyRevitLabs.NLog;
 using pyRevitLabs.Common;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public static class PyRevitConsts {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitEngine.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitEngine.cs
@@ -1,10 +1,7 @@
-﻿using System.IO;
-using System.Linq;
-using System.Collections.Generic;
+﻿using pyRevitLabs.Common.Extensions;
 
-using pyRevitLabs.Common.Extensions;
-
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public class PyRevitEngineVersion {
         static public PyRevitEngineVersion Default => new PyRevitEngineVersion(0);
         

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitEngines.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitEngines.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using pyRevitLabs.TargetApps.Revit;
 
-using pyRevitLabs.TargetApps.Revit;
-
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public static class PyRevitEngines {
         public static PyRevitEngine GetEngineFromManifest(RevitAddonManifest manifest, PyRevitClone clone) {
             foreach (var engine in clone.GetEngines())

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitExtension.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitExtension.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using pyRevitLabs.Common;
 
 using pyRevitLabs.Json.Linq;
 using pyRevitLabs.NLog;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public enum PyRevitExtensionTypes {
         Unknown,
         UIExtension,

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitExtensions.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitExtensions.cs
@@ -1,15 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Text.RegularExpressions;
-using System.Security.Principal;
-using System.Text;
 
 using pyRevitLabs.Common;
 using pyRevitLabs.Common.Extensions;
-
-using MadMilkman.Ini;
 using pyRevitLabs.Json.Linq;
 using pyRevitLabs.NLog;
 
@@ -18,9 +13,10 @@ using pyRevitLabs.NLog;
  *  - Shipped extensions are the ones shipped as part of a clone (builtin) and specific to a clone
  *  - Installed extensions are installed globally in paths. All clones will see these extension
  *  - Registered extensions are extension metadata registered in json files. They ar used to extract info about an extension and find the install source
- */ 
+ */
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public static class PyRevitExtensions {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitProduct.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitProduct.cs
@@ -1,17 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-
-using Microsoft.Win32;
 
 using pyRevitLabs.Common;
-using pyRevitLabs.Common.Extensions;
 using pyRevitLabs.NLog;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public class PyRevitProductInfo {
         public string product { get; set; }
         public string release { get; set; }

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitRelease.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitRelease.cs
@@ -1,12 +1,7 @@
-﻿using System;
+﻿using pyRevitLabs.Common;
 
-using pyRevitLabs.Common;
-using pyRevitLabs.Common.Extensions;
-
-using pyRevitLabs.NLog;
-using pyRevitLabs.Json.Linq;
-
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
 
     public class PyRevitRelease: GithubReleaseInfo {
         // Check whether this is a pyRevit release

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitReleases.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitReleases.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Text.RegularExpressions;
 
 using pyRevitLabs.Common;
 
 using pyRevitLabs.NLog;
-using pyRevitLabs.Json;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public static class PyRevitReleases {
         // private logger and data
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitRunner.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitRunner.cs
@@ -1,17 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Diagnostics;
-
+using System.IO;
 using pyRevitLabs.Common;
 using pyRevitLabs.Common.Extensions;
 using pyRevitLabs.NLog;
 using pyRevitLabs.TargetApps.Revit;
 
-namespace pyRevitLabs.PyRevit {
+namespace pyRevitLabs.PyRevit
+{
     public class PyRevitRunnerCommand {
         public PyRevitRunnerCommand(string commandPath) => Path = commandPath;
 

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitScript.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitScript.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace pyRevitLabs.PyRevit {
+﻿namespace pyRevitLabs.PyRevit
+{
     public enum PyRevitScriptTypes {
         Unknown,
         Python,

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/pyRevitLabs.PyRevit.csproj
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/pyRevitLabs.PyRevit.csproj
@@ -24,7 +24,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\pyRevitLabs.Common\pyRevitLabs.Common.csproj" />
-    <ProjectReference Include="..\pyRevitLabs.CommonWPF\pyRevitLabs.CommonWPF.csproj" />
     <ProjectReference Include="..\pyRevitLabs.TargetApps.Revit\pyRevitLabs.TargetApps.Revit.csproj" />
   </ItemGroup>
 

--- a/dev/pyRevitLabs/pyRevitLabs.TargetApps.Revit/RevitCaches.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.TargetApps.Revit/RevitCaches.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 using pyRevitLabs.Common;
 using pyRevitLabs.NLog;
 
-namespace pyRevitLabs.TargetApps.Revit {
+namespace pyRevitLabs.TargetApps.Revit
+{
     public enum RevitCacheType {
         BIM360Cache
     }

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/Template.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/Template.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using pyRevitLabs.Common;
 
-// https://docs.microsoft.com/en-us/visualstudio/test/getting-started-with-unit-testing
-namespace pyRevitLabs.UnitTests {
+namespace pyRevitLabs.UnitTests
+{
     [TestClass]
     public class TemplateUnitTest {
         private TestContext _testContextInstance;
@@ -15,7 +14,6 @@ namespace pyRevitLabs.UnitTests {
         [AssemblyInitialize()]
         public static void AssemblyInit(TestContext context) { }
 
-        //https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.testtools.unittesting.classinitializeattribute
         [ClassInitialize()]
         public static void ClassInit(TestContext context) { }
 
@@ -37,7 +35,6 @@ namespace pyRevitLabs.UnitTests {
             }
         }
 
-        // https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.testtools.unittesting.classcleanupattribute
         [ClassCleanup()]
         public static void ClassCleanup() { }
 

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.pyRevit.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.pyRevit.cs
@@ -1,17 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using pyRevitLabs.Common;
-using pyRevitLabs.TargetApps.Revit;
 using pyRevitLabs.PyRevit;
-using pyRevitLabs.UnitTests;
 
-namespace pyRevitLabs.UnitTests.pyRevit {
+namespace pyRevitLabs.UnitTests.pyRevit
+{
     [TestClass()]
     public class PyRevitTests: TemplateUnitTest {
         public override string TempPath =>


### PR DESCRIPTION
Hi, this is a draft before I leave for a short vacation...

I tried to add ILRepack task after the build, but it complains about not finding RevitAPI (which should be excluded, but it thows the error anyway).

I used [this package](https://github.com/ravibpatel/ILRepack.Lib.MSBuild.Task/tree/master), but I suppose that the complexity of our folder structure gets in our way...

[Here an article](https://www.meziantou.net/merging-assemblies-using-ilrepack.htm) on the subject as reference.
