### PR TITLE
Revert "small typo in consts"

### DIFF
--- a/dev/pyRevitLabs/pyRevitLabs.Common/Consts.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/Consts.cs
@@ -31,7 +31,8 @@ namespace pyRevitLabs.Common {
         public const string DefaultRemoteName = "origin";
         public const string OriginalRepoDefaultBranch = "master";
 
-        public const string TargetBranch = OriginalRepoDefaultBranch;
+        public const string TragetBranch = OriginalRepoDefaultBranch;
+        //public const string TragetBranch = @"develop/newexec";
 
         // consts for the official pyRevit repo
         public const string OriginalRepoName = ProductName;


### PR DESCRIPTION
Reverts pyrevitlabs/pyRevit#2364

Needs to look at it as the typo in the definition seems to be all over