### PR TITLE
fix(config): allow concurrent access to pyrevit_config.ini

### DIFF
--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitConfig.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 
 using pyRevitLabs.Common;
 using pyRevitLabs.Common.Extensions;
@@ -31,7 +32,9 @@ namespace pyRevitLabs.PyRevit {
                 cfgOps.Encoding = CommonUtils.GetUTF8NoBOMEncoding();
                 _config = new IniFile(cfgOps);
 
-                _config.Load(cfgFilePath);
+                using (var cfgStream = File.Open(cfgFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                    _config.Load(cfgStream);
+                }
                 _adminMode = adminMode;
             }
             else


### PR DESCRIPTION
fixes #2463 #2512

It seems to work on my machine, I ran 3 instances of revit 2023 one after another, and then 2 instances of revit 2025.