### PR TITLE
fix: incorrect handling of PYTHONPATH in SetupSearchPaths()

### DIFF
--- a/dev/pyRevitLabs.PyRevit.Runtime/CPythonEngine.cs
+++ b/dev/pyRevitLabs.PyRevit.Runtime/CPythonEngine.cs
@@ -205,7 +205,10 @@ namespace PyRevitLabs.PyRevit.Runtime {
                 var paths = pythonPath.Split(Path.PathSeparator);
                 foreach (var path in paths)
                 {
-                    sysPaths.Append(new PyString(path));
+                    if (!string.IsNullOrWhiteSpace(path) && Directory.Exists(path)) 
+                    {
+                        sysPaths.Append(new PyString(path)); 
+                    }
                 }
             }
 

--- a/dev/pyRevitLabs.PyRevit.Runtime/CPythonEngine.cs
+++ b/dev/pyRevitLabs.PyRevit.Runtime/CPythonEngine.cs
@@ -198,11 +198,15 @@ namespace PyRevitLabs.PyRevit.Runtime {
             // set sys paths
             PyList sysPaths = RestoreSearchPaths();
 
-            // manually add PYTHONPATH since we are overwriting the sys paths
+            // manually add each path in PYTHONPATH since we are overwriting the sys paths
             var pythonPath = Environment.GetEnvironmentVariable("PYTHONPATH");
             if (!string.IsNullOrEmpty(pythonPath))
             {
-                sysPaths.Append(new PyString(pythonPath));
+                var paths = pythonPath.Split(Path.PathSeparator);
+                foreach (var path in paths)
+                {
+                    sysPaths.Append(new PyString(path));
+                }
             }
 
             // now add the search paths for the script bundle


### PR DESCRIPTION
# Fix incorrect handling of PYTHONPATH in SetupSearchPaths()

## Description

The current implementation of importing PYTHONPATH in to sys.path in the python environment treats PYTHONPATH as a single value. This isn't always the case. It also doesn't follow the official specification for python which describes the value of PYTHONPATH as a list of paths. 

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [ ] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
