### PR TITLE
loading pyRevitLabs.json in PyrevitCLI manually if assembly is not found

### DIFF
--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLI.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLI.cs
@@ -89,6 +89,18 @@ namespace pyRevitCLI
 
         // cli entry point:
         static void Main(string[] args) {
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+            {
+                if (args.Name.Contains("Newtonsoft.Json"))
+                {
+                    var assemblyPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "pyRevitLabs.Json.dll");
+                    if (File.Exists(assemblyPath))
+                    {
+                        return Assembly.LoadFrom(assemblyPath);
+                    }
+                }
+                return null;
+            };
             // process arguments for logging level
             var argsList = new List<string>(args);
 

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLI.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLI.cs
@@ -94,9 +94,12 @@ namespace pyRevitCLI
                 if (args.Name.Contains("Newtonsoft.Json"))
                 {
                     var assemblyPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "pyRevitLabs.Json.dll");
+                    logger.Debug($"Looking for Newtonsoft.Json assembly at: {assemblyPath}");
                     if (File.Exists(assemblyPath))
                     {
-                        return Assembly.LoadFrom(assemblyPath);
+                        var assembly = Assembly.LoadFrom(assemblyPath);
+                        logger.Debug($"Successfully loaded Newtonsoft.Json assembly from: {assemblyPath}");
+                        return assembly;
                     }
                 }
                 return null;


### PR DESCRIPTION
# Name of your PR

## Description

I couldn't make the CLI work from the develop branch, it always resulted in
```powershell
❯ .\bin\pyrevit.exe env
==> Registered Clones (full git repos)
Error: Could not load file or assembly 'Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
Run with "--debug" option to see debug messages
```

The only way I've found to solve this issue is to explicitly force assembly resolution.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.


---

Thank you for contributing to pyRevit! 🎉
