### PR TITLE
less strict python version requirement to allow newer versions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,7 +26,7 @@ mkdocs-material = "*"
 ruff = "*"
 
 [requires]
-python_version = "3.10"
+python_version = ">=3.10"
 
 [pipenv]
 allow_prereleases = true


### PR DESCRIPTION
## Description

I'm currently using python 3.13 and it was incompatible with pipenv. This modification allowed me to run pipenv while keeping backward compatibility.
It worked for me, but I don't know what other consequences this change might have, so a review is welcome.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

Thank you for contributing to pyRevit! 🎉
