### PR TITLE
fix: Update SettingsWindow.xaml Name of variable

### DIFF
--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
@@ -448,7 +448,7 @@
                     <StackPanel Margin="10px">
                         <TextBlock x:Name="revitversions_tb" TextWrapping="WrapWithOverflow" Text="{DynamicResource SupportedRevitVersions.Description}"/>
                         <!--Link the list 'SupportedRevitVersions_CB' from python to the xaml-->
-                        <ItemsControl ItemsSource="{Binding SupportedRevitVersions_CB}">
+                        <ItemsControl ItemsSource="{Binding supported_revit_versions_CB}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
                                     <CheckBox Content="{Binding Content}"

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
@@ -447,7 +447,7 @@
                 <Expander Header="{DynamicResource SupportedRevitVersions.Title}" IsExpanded="False" Margin="10px">
                     <StackPanel Margin="10px">
                         <TextBlock x:Name="revitversions_tb" TextWrapping="WrapWithOverflow" Text="{DynamicResource SupportedRevitVersions.Description}"/>
-                        <!--Link the list 'SupportedRevitVersions_CB' from python to the xaml-->
+                        <!--Link the list 'supported_revit_versions_CB' from python to the xaml-->
                         <ItemsControl ItemsSource="{Binding supported_revit_versions_CB}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>


### PR DESCRIPTION
# Changing Variable Name

## Description

Change the name of the variable `supported_revit_versions_CB `in the XAML file to ensure it links correctly with the Python script.


