### PR TITLE
dev/#2606 Fix for orienting section box to faces of objects that have transformations

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/bundle.yaml
@@ -14,3 +14,4 @@ tooltip:
     Fläche im Modell ausgewählt werden. Mit der TAB Taste kann man zwischen angrenzenden
     Flächen durchwechseln. Eine Seite des 3D-Schnittbereichs übernimmt die 
     Ausrichtung der gewählten Fläche!
+context: active-3d-view

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/script.py
@@ -4,25 +4,29 @@ from pyrevit.framework import Math
 from pyrevit import revit, DB, UI
 from pyrevit import forms
 
+# import Autodesk.Revit
+
+import Autodesk.Revit.UI.Selection.ObjectType
 
 curview = revit.active_view
 
 
 def orientsectionbox(view):
         try:
-            # Pick face to align to
-            with forms.WarningBar(title='Pick a face to align to:'):
-                face = revit.pick_face()
+            # Pick face to align to using uidoc.Selection instead of revit.pick_face to get the reference instead of the face
+            face = revit.uidoc.Selection.PickObject(UI.Selection.ObjectType.Face, 'Pick a face to align to:')
+            
+            revit.pick_face
 
             # Get the section box
             box = view.GetSectionBox()
 
             # Get the geometry object of the reference
-            geometry_object = revit.doc.GetElement(face.ElementId).GetGeometryObjectFromReference(face)
+            element = revit.doc.GetElement(face)
+            geometry_object = element.GetGeometryObjectFromReference(face)
             
-            # Check if the object might have a Transformation (by checking if it's Non-Instance and not a System Family)
-            element = revit.doc.GetElement(face.ElementId)
-            if isinstance(element, DB.FamilyInstance) and element.Symbol.Family.FamilyType != DB.FamilyType.System:
+            # Check if the object might have a Transformation (by checking if it's Non-Instance)
+            if isinstance(element, DB.FamilyInstance):
                 # Get the transform of the family instance (converts local to world coordinates)
                 transform = element.GetTransform()
                 # Get the face normal in local coordinates
@@ -31,7 +35,7 @@ def orientsectionbox(view):
                 world_normal = transform.OfVector(local_normal).Normalize()
                 norm = world_normal
             else:
-                norm = face.ComputeNormal(DB.UV(0, 0)).Normalize()
+                norm = geometry_object.ComputeNormal(DB.UV(0, 0)).Normalize()
             
             # Orient the box
             boxNormal = box.Transform.Basis[0].Normalize()
@@ -48,11 +52,11 @@ def orientsectionbox(view):
                                                             angle,
                                                             origin)
             box.Transform = box.Transform.Multiply(rotate)
-            with revit.Transaction('Orient Section Box to Face'):
+            with revit.Transaction("Orient Section Box to Face"):
                 view.SetSectionBox(box)
                 revit.uidoc.RefreshActiveView()
-        except Exception:
-            passforms.alert('Error: {0}'.format(str(ex)))
+        except Exception as ex:
+            forms.alert('Error: {0}'.format(str(ex)))
 
 
 if isinstance(curview, DB.View3D) and curview.IsSectionBoxActive:
@@ -60,4 +64,4 @@ if isinstance(curview, DB.View3D) and curview.IsSectionBoxActive:
 elif isinstance(curview, DB.View3D) and not curview.IsSectionBoxActive:
     forms.alert("The section box for View3D isn't active.")
 else:
-    forms.alert('You must be on a 3D view for this tool to work.')
+    forms.alert("You must be on a 3D view for this tool to work.")

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/script.py
@@ -4,59 +4,60 @@ from pyrevit.framework import Math
 from pyrevit import revit, DB, UI
 from pyrevit import forms
 
-# import Autodesk.Revit
-
 import Autodesk.Revit.UI.Selection.ObjectType
 
 curview = revit.active_view
 
 
 def orientsectionbox(view):
-        try:
-            # Pick face to align to using uidoc.Selection instead of revit.pick_face to get the reference instead of the face
-            face = revit.uidoc.Selection.PickObject(UI.Selection.ObjectType.Face, 'Pick a face to align to:')
-            
-            revit.pick_face
+    try:
+        # Pick face to align to using uidoc.Selection instead of revit.pick_face to get the reference instead of the face
+        face = revit.uidoc.Selection.PickObject(
+            UI.Selection.ObjectType.Face, "Pick a face to align to:"
+        )
 
-            # Get the section box
-            box = view.GetSectionBox()
+        revit.pick_face
 
-            # Get the geometry object of the reference
-            element = revit.doc.GetElement(face)
-            geometry_object = element.GetGeometryObjectFromReference(face)
-            
-            # Check if the object might have a Transformation (by checking if it's Non-Instance)
-            if isinstance(element, DB.FamilyInstance):
-                # Get the transform of the family instance (converts local to world coordinates)
-                transform = element.GetTransform()
-                # Get the face normal in local coordinates
-                local_normal = geometry_object.ComputeNormal(DB.UV(0, 0)).Normalize()
-                # Apply the transform to convert normal to world coordinates
-                world_normal = transform.OfVector(local_normal).Normalize()
-                norm = world_normal
-            else:
-                norm = geometry_object.ComputeNormal(DB.UV(0, 0)).Normalize()
-            
-            # Orient the box
-            boxNormal = box.Transform.Basis[0].Normalize()
-            angle = norm.AngleTo(boxNormal)
-            axis = DB.XYZ(0, 0, 1.0)
-            origin = DB.XYZ(box.Min.X + (box.Max.X - box.Min.X) / 2,
-                            box.Min.Y + (box.Max.Y - box.Min.Y) / 2, 0.0)
-            if norm.Y * boxNormal.X < 0:
-                rotate = \
-                    DB.Transform.CreateRotationAtPoint(axis, Math.PI / 2 - angle,
-                                                       origin)
-            else:
-                rotate = DB.Transform.CreateRotationAtPoint(axis,
-                                                            angle,
-                                                            origin)
-            box.Transform = box.Transform.Multiply(rotate)
-            with revit.Transaction("Orient Section Box to Face"):
-                view.SetSectionBox(box)
-                revit.uidoc.RefreshActiveView()
-        except Exception as ex:
-            forms.alert('Error: {0}'.format(str(ex)))
+        # Get the section box
+        box = view.GetSectionBox()
+
+        # Get the geometry object of the reference
+        element = revit.doc.GetElement(face)
+        geometry_object = element.GetGeometryObjectFromReference(face)
+
+        # Check if the object might have a Transformation (by checking if it's Non-Instance)
+        if isinstance(element, DB.FamilyInstance):
+            # Get the transform of the family instance (converts local to world coordinates)
+            transform = element.GetTransform()
+            # Get the face normal in local coordinates
+            local_normal = geometry_object.ComputeNormal(DB.UV(0, 0)).Normalize()
+            # Apply the transform to convert normal to world coordinates
+            world_normal = transform.OfVector(local_normal).Normalize()
+            norm = world_normal
+        else:
+            norm = geometry_object.ComputeNormal(DB.UV(0, 0)).Normalize()
+
+        # Orient the box
+        boxNormal = box.Transform.Basis[0].Normalize()
+        angle = norm.AngleTo(boxNormal)
+        axis = DB.XYZ(0, 0, 1.0)
+        origin = DB.XYZ(
+            box.Min.X + (box.Max.X - box.Min.X) / 2,
+            box.Min.Y + (box.Max.Y - box.Min.Y) / 2,
+            0.0,
+        )
+        if norm.Y * boxNormal.X < 0:
+            rotate = DB.Transform.CreateRotationAtPoint(
+                axis, Math.PI / 2 - angle, origin
+            )
+        else:
+            rotate = DB.Transform.CreateRotationAtPoint(axis, angle, origin)
+        box.Transform = box.Transform.Multiply(rotate)
+        with revit.Transaction("Orient Section Box to Face"):
+            view.SetSectionBox(box)
+            revit.uidoc.RefreshActiveView()
+    except Exception as ex:
+        forms.alert("Error: {0}".format(str(ex)))
 
 
 if isinstance(curview, DB.View3D) and curview.IsSectionBoxActive:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/script.py
@@ -4,7 +4,7 @@ from pyrevit.framework import Math
 from pyrevit import revit, DB, UI
 from pyrevit import forms
 
-import Autodesk.Revit.UI.Selection.ObjectType
+from Autodesk.Revit.UI.Selection import ObjectType
 
 curview = revit.active_view
 
@@ -15,8 +15,6 @@ def orientsectionbox(view):
         face = revit.uidoc.Selection.PickObject(
             UI.Selection.ObjectType.Face, "Pick a face to align to:"
         )
-
-        revit.pick_face
 
         # Get the section box
         box = view.GetSectionBox()


### PR DESCRIPTION
# Fixed orienting the section boxes for family instances

## Description

The original code didn't work for families, that have been placed somewhere in open space, e.g. rotated generic models. Using this approach to take the object geometry instead of the face itself, transformation of the generic model can be obtained and taken into account.

I tried to use pyrevits pick_face(), but the reference of the face is always None when doing it that way. Not sure why.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

- Resolves #2606 

---

## Additional Notes

Tested in Revit 2024.

---

Thank you for contributing to pyRevit! 🎉
