### PR TITLE
Dev/2606 Fix for orienting view to faces of objects that have transformations

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient View To Face.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient View To Face.pushbutton/bundle.yaml
@@ -12,3 +12,5 @@ tooltip:
     Diese Skript richtet die aktuelle Kamera Ansicht senkrecht auf die 
     gewählte Fläche aus. Das Tool erstellt eine Skizzenebene über der 
     gewählten Fläche für die 3D Ansicht
+context: active-3d-view
+min_revit_version: 2016

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient View To Face.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient View To Face.pushbutton/script.py
@@ -2,6 +2,7 @@ from pyrevit import revit, DB, UI
 from pyrevit import forms
 
 from Autodesk.Revit.UI.Selection import ObjectType
+from Autodesk.Revit.Exceptions import OperationCanceledException
 
 curview = revit.active_view
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient View To Face.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient View To Face.pushbutton/script.py
@@ -44,9 +44,12 @@ def reorient(view):
             # orient the 3D view looking at the sketchplane
             view.OrientTo(norm.Negate())
             # set the sketchplane to active
-            revit.uidoc.ActiveView.SketchPlane = sp
+            view.SketchPlane = sp
 
         revit.uidoc.RefreshActiveView()
+
+    except OperationCanceledException:
+        pass
 
     except Exception as ex:
         forms.alert("Error: {0}".format(str(ex)))


### PR DESCRIPTION
# dev/#2606 Fix for orienting view to faces of objects that have transformations

## Description

The original code didn't work for families, that have been placed somewhere in open space, e.g. rotated generic models. Using this approach to take the object geometry instead of the face itself, transformation of the generic model can be obtained and taken into account.

I tried to use pyrevits pick_face(), but the reference of the face is always None when doing it that way. Not sure why.

The code is similar to #2619 

Added context and min revit version to bundle.yaml

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

- Resolves #2606

---

## Additional Notes

ran flake8
ran black

---

Thank you for contributing to pyRevit! 🎉
