### PR TITLE
Fix/2633 - Callable Import Error

### DIFF
--- a/pyrevitlib/pyrevit/compat.py
+++ b/pyrevitlib/pyrevit/compat.py
@@ -27,14 +27,14 @@ if PY3:
 if PY2:
     import _winreg as winreg
     import ConfigParser as configparser
-    from collections import Iterable
+    from collections import Iterable, Callable
     import urllib2
     from urlparse import urlparse
 
 elif PY3:
     import winreg as winreg
     import configparser as configparser
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Callable
     import urllib
     from urllib.parse import urlparse
 

--- a/pyrevitlib/pyrevit/coreutils/pyutils.py
+++ b/pyrevitlib/pyrevit/coreutils/pyutils.py
@@ -10,9 +10,9 @@ Examples:
 import re
 import copy
 from itertools import tee
-from collections import OrderedDict, Callable   #pylint: disable=E0611
+from collections import OrderedDict
 
-from pyrevit.compat import PY2
+from pyrevit.compat import PY2, Callable
 if PY2:
     from itertools import izip as zip
 


### PR DESCRIPTION
# Callable Import Error

## Description

Callable deprecated starting 3.3 and removed in 3.10

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

- Resolves #2633 

