### PR TITLE
LibGit2Sharp missing CredentialsProvider fix

### DIFF
--- a/pyrevitlib/pyrevit/coreutils/git.py
+++ b/pyrevitlib/pyrevit/coreutils/git.py
@@ -116,13 +116,18 @@ def _make_fetch_options(repo_info):
 def _make_clone_options(username=None, password=None):
     mlogger.debug('Making clone options.')
     clone_ops = libgit.CloneOptions()
-    if username and password:
-        mlogger.debug('Making Credentials handler. '
-                      '(Username and password are available but'
-                      'will not be logged for privacy purposes.)')
 
-        clone_ops.CredentialsProvider = \
-            _get_credentials_hndlr(username, password)
+    if username and password:
+        mlogger.debug('Making Credentials handler.')
+        creds_handler = _get_credentials_hndlr(username, password)
+
+        # Only set the CredentialsProvider if it's a valid property
+        if hasattr(clone_ops, 'CredentialsProvider'):
+            clone_ops.CredentialsProvider = creds_handler
+        elif hasattr(clone_ops, 'FetchOptions') and hasattr(clone_ops.FetchOptions, 'CredentialsProvider'):
+            clone_ops.FetchOptions.CredentialsProvider = creds_handler
+        else:
+            mlogger.warning('CloneOptions does not support CredentialsProvider. Skipping credentials.')
 
     return clone_ops
 

--- a/pyrevitlib/pyrevit/coreutils/git.py
+++ b/pyrevitlib/pyrevit/coreutils/git.py
@@ -16,14 +16,14 @@ from pyrevit.framework import clr
 from pyrevit.framework import DateTime, DateTimeOffset
 from pyrevit.coreutils.logger import get_logger
 
-#pylint: disable=W0703,C0302
-mlogger = get_logger(__name__)  #pylint: disable=C0103
+# pylint: disable=W0703,C0302
+mlogger = get_logger(__name__)  # pylint: disable=C0103
 
 
-GIT_LIB = 'LibGit2Sharp'
+GIT_LIB = "LibGit2Sharp"
 
 LIBGIT_DLL = framework.get_dll_file(GIT_LIB)
-mlogger.debug('Loading dll: %s', LIBGIT_DLL)
+mlogger.debug("Loading dll: %s", LIBGIT_DLL)
 
 try:
     if PY3:
@@ -31,16 +31,21 @@ try:
     else:
         clr.AddReferenceToFileAndPath(LIBGIT_DLL)
 
-    import LibGit2Sharp as libgit   #pylint: disable=import-error
+    import LibGit2Sharp as libgit  # pylint: disable=import-error
 
 except Exception as load_err:
-    mlogger.error('Can not load %s module. '
-                    'This module is necessary for getting pyRevit version '
-                    'and staying updated. | %s', GIT_LIB, load_err)
+    mlogger.error(
+        "Can not load %s module. "
+        "This module is necessary for getting pyRevit version "
+        "and staying updated. | %s",
+        GIT_LIB,
+        load_err,
+    )
 
 
 class PyRevitGitAuthenticationError(PyRevitException):
     """Git authentication error."""
+
     pass
 
 
@@ -57,6 +62,7 @@ class RepoInfo(object):
         username (str): credentials - username
         password (str): credentials - password
     """
+
     def __init__(self, repo):
         self.directory = repo.Info.WorkingDirectory
         self.name = op.basename(op.normpath(self.directory))
@@ -67,8 +73,9 @@ class RepoInfo(object):
         self.username = self.password = None
 
     def __repr__(self):
-        return '<type \'RepoInfo\' head \'{}\' @ {}>'\
-            .format(self.last_commit_hash, self.directory)
+        return "<type 'RepoInfo' head '{}' @ {}>".format(
+            self.last_commit_hash, self.directory
+        )
 
 
 def _credentials_hndlr(username, password):
@@ -79,69 +86,79 @@ def _credentials_hndlr(username, password):
 
 
 def _get_credentials_hndlr(username, password):
-    return libgit.Handlers. \
-           CredentialsHandler(lambda url, uname, types:
-                              _credentials_hndlr(username, password))
+    return libgit.Handlers.CredentialsHandler(
+        lambda url, uname, types: _credentials_hndlr(username, password)
+    )
 
 
 def _make_pull_options(repo_info):
-    mlogger.debug('Making pull options: %s', repo_info)
+    mlogger.debug("Making pull options: %s", repo_info)
     pull_ops = libgit.PullOptions()
     pull_ops.FetchOptions = libgit.FetchOptions()
     if repo_info.username and repo_info.password:
-        mlogger.debug('Making Credentials handler. '
-                      '(Username and password are available but'
-                      'will not be logged for privacy purposes.)')
+        mlogger.debug(
+            "Making Credentials handler. "
+            "(Username and password are available but"
+            "will not be logged for privacy purposes.)"
+        )
 
-        pull_ops.FetchOptions.CredentialsProvider = \
-            _get_credentials_hndlr(repo_info.username, repo_info.password)
+        pull_ops.FetchOptions.CredentialsProvider = _get_credentials_hndlr(
+            repo_info.username, repo_info.password
+        )
 
     return pull_ops
 
 
 def _make_fetch_options(repo_info):
-    mlogger.debug('Making fetch options: %s', repo_info)
+    mlogger.debug("Making fetch options: %s", repo_info)
     fetch_ops = libgit.FetchOptions()
     if repo_info.username and repo_info.password:
-        mlogger.debug('Making Credentials handler. '
-                      '(Username and password are available but'
-                      'will not be logged for privacy purposes.)')
+        mlogger.debug(
+            "Making Credentials handler. "
+            "(Username and password are available but"
+            "will not be logged for privacy purposes.)"
+        )
 
-        fetch_ops.CredentialsProvider = \
-            _get_credentials_hndlr(repo_info.username, repo_info.password)
+        fetch_ops.CredentialsProvider = _get_credentials_hndlr(
+            repo_info.username, repo_info.password
+        )
 
     return fetch_ops
 
 
 def _make_clone_options(username=None, password=None):
-    mlogger.debug('Making clone options.')
+    mlogger.debug("Making clone options.")
     clone_ops = libgit.CloneOptions()
 
     if username and password:
-        mlogger.debug('Making Credentials handler.')
+        mlogger.debug("Making Credentials handler.")
         creds_handler = _get_credentials_hndlr(username, password)
 
         # Only set the CredentialsProvider if it's a valid property
-        if hasattr(clone_ops, 'CredentialsProvider'):
+        if hasattr(clone_ops, "CredentialsProvider"):
             clone_ops.CredentialsProvider = creds_handler
-        elif hasattr(clone_ops, 'FetchOptions') and hasattr(clone_ops.FetchOptions, 'CredentialsProvider'):
+        elif hasattr(clone_ops, "FetchOptions") and hasattr(
+            clone_ops.FetchOptions, "CredentialsProvider"
+        ):
             clone_ops.FetchOptions.CredentialsProvider = creds_handler
         else:
-            mlogger.warning('CloneOptions does not support CredentialsProvider. Skipping credentials.')
+            mlogger.warning(
+                "CloneOptions does not support CredentialsProvider. Skipping credentials."
+            )
 
     return clone_ops
 
 
 def _make_pull_signature():
-    mlogger.debug('Creating pull signature for username: %s', HOST_APP.username)
-    return libgit.Signature(HOST_APP.username,
-                            HOST_APP.username,
-                            DateTimeOffset(DateTime.Now))
+    mlogger.debug("Creating pull signature for username: %s", HOST_APP.username)
+    return libgit.Signature(
+        HOST_APP.username, HOST_APP.username, DateTimeOffset(DateTime.Now)
+    )
 
 
 def _process_git_error(exception_err):
     exception_msg = safe_strtype(exception_err)
-    if '401' in exception_msg:
+    if "401" in exception_msg:
         raise PyRevitGitAuthenticationError(exception_msg)
     else:
         raise PyRevitException(exception_msg)
@@ -171,18 +188,18 @@ def git_pull(repo_info):
     """
     repo = repo_info.repo
     try:
-        libgit.Commands.Pull(repo,
-                             _make_pull_signature(),
-                             _make_pull_options(repo_info))
+        libgit.Commands.Pull(
+            repo, _make_pull_signature(), _make_pull_options(repo_info)
+        )
 
-        mlogger.debug('Successfully pulled repo: %s', repo_info.directory)
-        head_msg = safe_strtype(repo.Head.Tip.Message).replace('\n', '')
+        mlogger.debug("Successfully pulled repo: %s", repo_info.directory)
+        head_msg = safe_strtype(repo.Head.Tip.Message).replace("\n", "")
 
-        mlogger.debug('New head is: %s > %s', repo.Head.Tip.Id.Sha, head_msg)
+        mlogger.debug("New head is: %s > %s", repo.Head.Tip.Id.Sha, head_msg)
         return RepoInfo(repo)
 
     except Exception as pull_err:
-        mlogger.debug('Failed git pull: %s | %s', repo_info.directory, pull_err)
+        mlogger.debug("Failed git pull: %s | %s", repo_info.directory, pull_err)
         _process_git_error(pull_err)
 
 
@@ -197,21 +214,22 @@ def git_fetch(repo_info):
     """
     repo = repo_info.repo
     try:
-        libgit.Commands.Fetch(repo,
-                              repo.Head.TrackedBranch.RemoteName,
-                              [],
-                              _make_fetch_options(repo_info),
-                              'fetching pyrevit updates')
+        libgit.Commands.Fetch(
+            repo,
+            repo.Head.TrackedBranch.RemoteName,
+            [],
+            _make_fetch_options(repo_info),
+            "fetching pyrevit updates",
+        )
 
-        mlogger.debug('Successfully pulled repo: %s', repo_info.directory)
-        head_msg = safe_strtype(repo.Head.Tip.Message).replace('\n', '')
+        mlogger.debug("Successfully pulled repo: %s", repo_info.directory)
+        head_msg = safe_strtype(repo.Head.Tip.Message).replace("\n", "")
 
-        mlogger.debug('New head is: %s > %s', repo.Head.Tip.Id.Sha, head_msg)
+        mlogger.debug("New head is: %s > %s", repo.Head.Tip.Id.Sha, head_msg)
         return RepoInfo(repo)
 
     except Exception as fetch_err:
-        mlogger.debug('Failed git fetch: %s | %s',
-                      repo_info.directory, fetch_err)
+        mlogger.debug("Failed git fetch: %s | %s", repo_info.directory, fetch_err)
         _process_git_error(fetch_err)
 
 
@@ -225,16 +243,18 @@ def git_clone(repo_url, clone_dir, username=None, password=None):
         password (str): credentials - password
     """
     try:
-        libgit.Repository.Clone(repo_url,
-                                clone_dir,
-                                _make_clone_options(username=username,
-                                                    password=password))
+        libgit.Repository.Clone(
+            repo_url,
+            clone_dir,
+            _make_clone_options(username=username, password=password),
+        )
 
-        mlogger.debug('Completed git clone: %s @ %s', repo_url, clone_dir)
+        mlogger.debug("Completed git clone: %s @ %s", repo_url, clone_dir)
 
     except Exception as clone_err:
-        mlogger.debug('Error cloning repo: %s to %s | %s',
-                      repo_url, clone_dir, clone_err)
+        mlogger.debug(
+            "Error cloning repo: %s to %s | %s", repo_url, clone_dir, clone_err
+        )
         _process_git_error(clone_err)
 
 
@@ -248,28 +268,31 @@ def compare_branch_heads(repo_info):
     repo = repo_info.repo
     repo_branches = repo.Branches
 
-    mlogger.debug('Repo branches: %s', [b.FriendlyName for b in repo_branches])
+    mlogger.debug("Repo branches: %s", [b.FriendlyName for b in repo_branches])
 
     for branch in repo_branches:
         if branch.FriendlyName == repo_info.branch and not branch.IsRemote:
             try:
                 if branch.TrackedBranch:
-                    mlogger.debug('Comparing heads: %s of %s',
-                                  branch.CanonicalName,
-                                  branch.TrackedBranch.CanonicalName)
+                    mlogger.debug(
+                        "Comparing heads: %s of %s",
+                        branch.CanonicalName,
+                        branch.TrackedBranch.CanonicalName,
+                    )
 
-                    hist_div = repo.ObjectDatabase. \
-                        CalculateHistoryDivergence(branch.Tip,
-                                                   branch.TrackedBranch.Tip)
+                    hist_div = repo.ObjectDatabase.CalculateHistoryDivergence(
+                        branch.Tip, branch.TrackedBranch.Tip
+                    )
                     return hist_div
             except Exception as compare_err:
-                mlogger.error('Can not compare branch %s in repo: %s | %s',
-                              branch,
-                              repo,
-                              safe_strtype(compare_err).replace('\n', ''))
+                mlogger.error(
+                    "Can not compare branch %s in repo: %s | %s",
+                    branch,
+                    repo,
+                    safe_strtype(compare_err).replace("\n", ""),
+                )
         else:
-            mlogger.debug('Skipping remote branch: %s', branch.CanonicalName)
-
+            mlogger.debug("Skipping remote branch: %s", branch.CanonicalName)
 
 
 def get_all_new_commits(repo_info):
@@ -284,8 +307,7 @@ def get_all_new_commits(repo_info):
     repo = repo_info.repo
     current_commit = repo_info.last_commit_hash
 
-    ref_commit = repo.Lookup(libgit.ObjectId(current_commit),
-                             libgit.ObjectType.Commit)
+    ref_commit = repo.Lookup(libgit.ObjectId(current_commit), libgit.ObjectType.Commit)
 
     # Let's only consider the refs that lead to this commit...
     refs = repo.Refs.ReachableFrom([ref_commit])
@@ -299,8 +321,7 @@ def get_all_new_commits(repo_info):
     commits = repo.Commits.QueryBy(commit_filter)
     commitsdict = OrderedDict()
     for commit in commits:
-        if commit in repo.Head.Commits \
-                or commit in repo.Head.TrackedBranch.Commits:
+        if commit in repo.Head.Commits or commit in repo.Head.TrackedBranch.Commits:
             commitsdict[commit.Id.ToString()] = commit.MessageShort
 
     return commitsdict


### PR DESCRIPTION
# LibGit2Sharp missing CredentialsProvider fix

## Description

The purpose of this PR is to resolve a long-standing bug where using a different version of `LibGit2Sharp` library will produce the following error when trying to install an extension from a private GitHub repository:

![image](https://github.com/user-attachments/assets/8c1fe08e-baad-48ec-ac27-a78534b7f4d2)

The proposed fix is to check if the `CredentialsProvider` property exists in the current API and only provide it then. 

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [ ] Changes are tested and verified to work as expected.

---

## Related Issues

- n/a

---

## Additional Notes

- currently runs into an error if using a different `LibGit2Sharp` version **not** expecting `CredentialsProvider` property

