### PR TITLE
fix: is_schedule

### DIFF
--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -1364,7 +1364,7 @@ def is_schedule(view):
         isintkeynote = view.IsInternalKeynoteSchedule
         iskeynotelegend = (
             view.Definition.CategoryId
-            == get_category(DB.BuiltInCategory.OST_KeynoteTags).Id
+            == get_category(DB.BuiltInCategory.OST_KeynoteTags, view.Document).Id
         )
 
         return not (isrevsched or isintkeynote or iskeynotelegend)


### PR DESCRIPTION
# Fix bug in query get_all_schedules  

## Description

This pull request addresses an issue encountered when calling the ```get_all_schedules``` function in the ```query.py``` module. The error,  ```AttributeError: 'NoneType' object has no attribute 'Settings'```, occurs when attempting to retrieve schedules from a document that has been just opened with ```HOST_APP.app.OpenDocumentFile()``` method.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
- [x] Changes are tested and verified to work as expected.
