### PR TITLE
missing comma in the docs for CommandSwitchWindow

### DIFF
--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -1239,7 +1239,7 @@ class CommandSwitchWindow(TemplateUserInputWindow):
         cfgs = {'option1': { 'background': '0xFF55FF'}}
         rops, rswitches = forms.CommandSwitchWindow.show(
             ops,
-            switches=switches
+            switches=switches,
             message='Select Option',
             config=cfgs,
             recognize_access_key=False


### PR DESCRIPTION

# missing comma in the docs for CommandSwitchWindow

## Description

Just added a comma in the docs for CommandSwitchWindow
---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [ ] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
