### PR TITLE
Update Create Revised Sheet Set, to Give the users control to Set the…

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Revision.pulldown/Create Revised Sheet Set.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Revision.pulldown/Create Revised Sheet Set.pushbutton/script.py
@@ -1,25 +1,42 @@
 #pylint: disable=E0401,C0103,C0111
 from pyrevit import revit
-from pyrevit import forms
+from pyrevit import forms, script
 
 
 revisions = forms.select_revisions(button_name='Create Sheet Set',
                                    multiple=True)
+
 if revisions:
+    revision_names = [revision.Name for revision in revisions]
     if len(revisions) > 1:
         selected_switch = \
             forms.CommandSwitchWindow.show(['Matching ANY revision',
                                             'Matching ALL revisions'],
                                            message='Pick an option:')
+        name_str = "{}".format(" & ".join(revision_names))
     else:
         selected_switch = 'Matching ALL revisions'
-
+        name_str = revision_names[0]
+    set_name = forms.ask_for_string(
+        prompt='Enter a name for the new revision sheet set:',
+        default=name_str,
+        title='Revision Sheet Set',
+        ok_text='Create',
+        cancel_text='Cancel'
+    )
+    if not set_name:
+        forms.alert('No name provided. Exiting.')
+        script.exit()
     if selected_switch:
         match_any = (selected_switch == 'Matching ANY revision')
+
         with revit.Transaction('Create Revision Sheet Set'):
             rev_sheetset = \
-                revit.create.create_revision_sheetset(revisions,
-                                                      match_any=match_any)
+                revit.create.create_revision_sheetset(
+                                                revisions,
+                                                name_format=set_name,
+                                                match_any=match_any
+                    )
 
         empty_sheets = []
         for sheet in rev_sheetset:


### PR DESCRIPTION
… name of the set before creation

I'm proposing to add a forms.ask_for_string prompt to the users to name their set in the fly instead of going there manually and name their revision after creation.


# Name of your PR

## Description

Please provide a brief description of the changes introduced in this pull request. Explain the purpose of these changes and their intended effect on the project.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [ ] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
