### PR TITLE
fix #2678: use binary mode for pickle load and dump

### DIFF
--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -717,7 +717,7 @@ def store_data(slot_name, data, this_project=True):
                                   file_ext=DATAFEXT,
                                   add_cmd_name=False)
 
-    with open(data_file, 'w') as dfile:
+    with open(data_file, "wb") as dfile:
         pickle.dump(data, dfile)
 
 
@@ -774,7 +774,7 @@ def load_data(slot_name, this_project=True):
                                   file_ext=DATAFEXT,
                                   add_cmd_name=False)
 
-    with open(data_file, 'r') as dfile:
+    with open(data_file, 'rb') as dfile:
         return pickle.load(dfile)
 
 


### PR DESCRIPTION
# Fix: use binary mode for pickle load and dump

## Description

This pull request fixes an issue with file modes used in pickle.dump() and pickle.load() operations. Previously, files were being opened in text mode ("w"/"r"), which caused errors in IronPython (e.g. UnicodeDecodeError) due to improper decoding of binary pickle data.

### Changes made:

    Changed open(..., "w") to open(..., "wb") when writing pickled data.

    Changed open(..., "r") to open(..., "rb") when reading pickled data.
These changes ensure binary-safe file I/O and improve compatibility across Python implementations including IronPython and CPython.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2678 

---

## Additional Notes

Fix tested successfully on IronPython 3.4.2 and IronPython 2.7.12 environment in Revit 2024.

Prevents cross-platform decoding issues when reading/writing pickled files.

---

Thank you for contributing to pyRevit! 🎉
