### PR TITLE
Color Splasher : Wrong Revit API Class invocation

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/ColorSplasher.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/ColorSplasher.pushbutton/script.py
@@ -137,10 +137,10 @@ class ApplyColors(UI.IExternalEventHandler):
                 ):
                     # In case of rooms, spaces and areas. Check Color scheme is applied and if not
                     if version > 2021:
-                        if wndw.crt_view.GetColorFillSchemeId(sel_cat.cat.Id).ToString() is "-1":
+                        if wndw.crt_view.GetColorFillSchemeId(sel_cat.cat.Id).ToString() == "-1":
                             color_schemes = (
                                 DB.FilteredElementCollector(new_doc)
-                                .OfClass(DB.BuiltInCategoryFillScheme)
+                                .OfClass(DB.ColorFillScheme)
                                 .ToElements()
                             )
                             if len(color_schemes) > 0:


### PR DESCRIPTION
## Description

fixes properly #2684 (and #2690 I was too quick on the button 😄  )

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2684 