### PR TITLE
fix bitmap_from_file method in utils.py

### DIFF
--- a/pyrevitlib/pyrevit/forms/utils.py
+++ b/pyrevitlib/pyrevit/forms/utils.py
@@ -1,21 +1,21 @@
 """Utility functions to support forms module."""
 
 from pyrevit import framework
-from pyrevit.framework import wpf, Controls, Imaging
+from pyrevit.framework import wpf, Controls, Imaging, Uri, UriKind
 
 
 def bitmap_from_file(bitmap_file):
     """Create BitmapImage from a bitmap file.
 
     Args:
-        bitmap_file (str): path to bitmap file
+        bitmap_file (str): absolute path to bitmap file
 
     Returns:
         (BitmapImage): bitmap image object
     """
     bitmap = Imaging.BitmapImage()
     bitmap.BeginInit()
-    bitmap.UriSource = framework.Uri(bitmap_file)
+    _, bitmap.UriSource = Uri.TryCreate(bitmap_file, UriKind.RelativeOrAbsolute)
     bitmap.CacheOption = Imaging.BitmapCacheOption.OnLoad
     bitmap.CreateOptions = Imaging.BitmapCreateOptions.IgnoreImageCache
     bitmap.EndInit()


### PR DESCRIPTION

# Fix bitmap_from_file method in utils.py

## Description

Explicitly provide UriKind to Uri constructor in bitmap_from_file method.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2699 

