### PR TITLE
Enhance font replacement functionality in Revit families

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Replace_Fonts.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Replace_Fonts.pushbutton/script.py
@@ -19,13 +19,13 @@ output = script.get_output()
 logger = script.get_logger()
 
 
-def rename_element_type_if_needed(element_type, old_font, new_font):
+def rename_element_type_if_needed(element_type, old_font, new_font_name):
     # type: (DB.ElementType, str, str) -> None
     """Renames an element type if its name contains the old font name (case-insensitive).
     Args:
         element_type (DB.ElementType): The element type to rename.
         old_font (str): The old font name.
-        new_font (str): The new font name.
+        new_font_name (str): The new font name.
     Returns:
         None
     """

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Replace_Fonts.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Replace_Fonts.pushbutton/script.py
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# -*- coding: UTF-8 -*-
 import System
 import re
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Replace_Fonts.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Replace_Fonts.pushbutton/script.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 import System
+import re
 
 from rpw.ui.forms import (
     FlexForm,
@@ -18,9 +19,178 @@ output = script.get_output()
 logger = script.get_logger()
 
 
+def rename_element_type_if_needed(element_type, old_font, new_font):
+    # type: (DB.ElementType, str, str) -> None
+    """Renames an element type if its name contains the old font name (case-insensitive).
+    Args:
+        element_type (DB.ElementType): The element type to rename.
+        old_font (str): The old font name.
+        new_font (str): The new font name.
+    Returns:
+        None
+    """
+    current_name = DB.Element.Name.GetValue(element_type)
+    # Use case-insensitive check to see if the old font name is part of the type name
+    if old_font.lower() in current_name.lower():
+        # Use case-insensitive replace
+        try:
+            new_name = re.sub(re.escape(old_font), new_font, current_name, flags=re.IGNORECASE)
+            if new_name != current_name:
+                DB.Element.Name.SetValue(element_type, new_name)
+                logger.debug("Renamed type from '{}' to '{}'".format(current_name, new_name))
+        except Exception as e:
+            # Log error if renaming fails, but don't stop the script
+            logger.error("Failed to rename type '{}' to '{}': {}".format(current_name, new_name, e))
+
+
+def update_nested_generic_annotations(host_family_doc, font_name):
+    # type: (DB.Document, str) -> tuple[list[tuple[str, str, str]], bool]
+    """
+    Recursively finds and updates fonts in nested generic annotation families.
+    Args:
+        host_family_doc (DB.Document): The host family document.
+        font_name (str): The new font name.
+    Returns:
+        tuple: A tuple containing:
+            - result (list): A list of tuples with details of updated elements.
+            - found (bool): A boolean indicating if any updates were made.
+    """
+    results = []
+    found_in_any_nested = False
+
+    # Find nested families of category "Generic Annotation"
+    nested_families = [
+        f
+        for f in DB.FilteredElementCollector(host_family_doc)
+        .OfClass(DB.Family)
+        .ToElements()
+        if f.FamilyCategory
+        and f.FamilyCategory.Id.IntegerValue
+        == int(DB.BuiltInCategory.OST_GenericAnnotation)
+    ]
+
+    for nested_family in nested_families:
+        if not nested_family.IsEditable:
+            continue
+
+        try:
+            nested_family_doc = host_family_doc.EditFamily(nested_family)
+
+            found_in_this_nested = False
+
+            # Update text types within this nested family
+            bip = DB.BuiltInParameter.TEXT_FONT
+            element_types = (
+                DB.FilteredElementCollector(nested_family_doc)
+                .OfClass(DB.ElementType)
+                .ToElements()
+            )
+
+            with revit.Transaction("Update Font in Nested Family", nested_family_doc):
+                for et in element_types:
+                    param = et.get_Parameter(bip)
+                    if param and param.HasValue:
+                        old_font = param.AsString()
+                        if old_font != font_name:
+                            rename_element_type_if_needed(et, old_font, font_name)
+                            param.Set(font_name)
+                            found_in_this_nested = True
+                            # Report the name of the type that was changed
+                            results.append(
+                                (DB.Element.Name.GetValue(et), old_font, font_name)
+                            )
+
+                # Recursive call for families nested even deeper
+                nested_results, nested_found = update_nested_generic_annotations(
+                    nested_family_doc, font_name
+                )
+                if nested_found:
+                    results.extend(nested_results)
+                    found_in_this_nested = True
+
+            if found_in_this_nested:
+                found_in_any_nested = True
+                # Load the updated nested family back into its host family
+                nested_family_doc.LoadFamily(host_family_doc, FamilyLoaderOptionsHandler())
+
+            nested_family_doc.Close(False)
+        except Exception as e:
+            logger.error(
+                "Error processing nested family '{}' in '{}': {}".format(
+                    nested_family.Name, host_family_doc.Title, e
+                )
+            )
+            continue
+
+    return results, found_in_any_nested
+
+
+def process_family_document(family_doc, new_font_name):
+    # type: (DB.Document, str) -> tuple[list[tuple[str, str, str]], bool]
+    """
+    Updates all applicable fonts in the given family document, including nested ones.
+    Args:
+        family_doc (DB.Document): The family document to process.
+        new_font_name (str): The new font name.
+    Returns:
+        tuple: A tuple containing:
+            - result (list): A list of tuples with details of updated elements.
+            - found (bool): A boolean indicating if any updates were made.
+    """
+    result = []
+    found = False
+    bip = DB.BuiltInParameter.TEXT_FONT
+
+    with revit.TransactionGroup("Update Font in Family and Nested", family_doc):
+        # Update types in the main family document
+        with revit.Transaction("Update Font in Family", family_doc):
+            element_types = (
+                DB.FilteredElementCollector(family_doc)
+                .OfClass(DB.ElementType)
+                .ToElements()
+            )
+            
+            for element_type in element_types:
+                try:
+                    param = element_type.get_Parameter(bip)
+                    if param and param.HasValue:
+                        old_font = param.AsString()
+                        if old_font != new_font_name:
+                            rename_element_type_if_needed(element_type, old_font, new_font_name)
+                            param.Set(new_font_name)
+                            found = True
+                            result.append(
+                                (
+                                    DB.Element.Name.GetValue(element_type),
+                                    old_font,
+                                    new_font_name,
+                                )
+                            )
+                except Exception as e:
+                    logger.error(
+                        "Error updating type '{}' in family '{}': {}".format(
+                            DB.Element.Name.GetValue(element_type),
+                            family_doc.Title,
+                            str(e),
+                        )
+                    )
+                    continue
+
+        # Process nested generic annotations
+        nested_results, nested_found = update_nested_generic_annotations(
+            family_doc, new_font_name)
+        if nested_found:
+            found = True
+            result.extend(nested_results)
+    
+    return result, found
+
+
 def update_text_font_in_family(doc, family, font_name):
+    # type: (DB.Document, DB.Family, str) -> tuple[list[tuple[str, str, str]], bool]
     """
     Updates the text font in a Revit family to the specified font name.
+    Also processes nested generic annotation families.
     Args:
         doc (DB.Document): The current Revit document.
         family (DB.Family): The Revit family to update.
@@ -28,43 +198,27 @@ def update_text_font_in_family(doc, family, font_name):
     Returns:
         tuple: A tuple containing:
             - result (list): A list of tuples with details of updated elements in the format
-              (element family name, old font name, new font name).
+              (element type name, old font name, new font name).
             - found (bool): A boolean indicating whether any text font parameters were found and updated.
     Raises:
         SystemError: If a system-level error occurs during the operation.
         ValueError: If an invalid value is encountered during the operation.
     """
     try:
-        result = []
-        bip = DB.BuiltInParameter.TEXT_FONT
         family_doc = doc.EditFamily(family)
-        element_types = (
-            DB.FilteredElementCollector(family_doc).OfClass(DB.ElementType).ToElements()
-        )
-        with revit.Transaction("Update Font", family_doc):
-            found = False
-            for element_type in element_types:
-                try:
-                    param = element_type.get_Parameter(bip)
-                    if param and param.HasValue:
-                        old_font = param.AsString()
-                        param.Set(font_name)
-                        found = True
-                        result.append((element_type.FamilyName, old_font, font_name))
-                except Exception as e:
-                    logger.error(
-                        "Error updating {}: {}".format(element_type.FamilyName, str(e))
-                    )
-                    continue
+        result, found = process_family_document(family_doc, font_name)
+
         if found:
             family_doc.LoadFamily(doc, FamilyLoaderOptionsHandler())
         family_doc.Close(False)
         return result, found
-    except (SystemError, ValueError):
+    except (SystemError, ValueError) as e:
+        logger.error("Could not process family '{}': {}".format(family.Name, e))
         return [], False
 
 
 def update_text_types(doc, element_types, font_name):
+    # type: (DB.Document, list[DB.ElementType], str) -> list[tuple]
     """
     Updates the font of specified text element types in a Revit document.
     Args:
@@ -86,10 +240,12 @@ def update_text_types(doc, element_types, font_name):
                 param = elem_type.get_Parameter(bip)
                 if param and param.HasValue:
                     old_font = param.AsString()
-                    param.Set(font_name)
-                    results.append(
-                        (DB.Element.Name.GetValue(elem_type), old_font, font_name)
-                    )
+                    if old_font != font_name:
+                        rename_element_type_if_needed(elem_type, old_font, font_name)
+                        param.Set(font_name)
+                        results.append(
+                            (DB.Element.Name.GetValue(elem_type), old_font, font_name)
+                        )
             except Exception as e:
                 logger.error(
                     "**Error updating {}: {}**".format(
@@ -103,14 +259,54 @@ def main():
     doc = HOST_APP.doc
     uidoc = HOST_APP.uidoc
 
+    # Get list of system fonts
     font_families = System.Drawing.FontFamily.Families
     font_names = [font_family.Name for font_family in font_families]
     font_names.sort()
 
+    # --- LOGIC FOR FAMILY DOCUMENT ---
+    if doc.IsFamilyDocument:
+        components = [
+            Label("Replace all fonts in this family."),
+            Separator(),
+            Label("Select Target Font:"),
+            ComboBox("font", options=font_names, default="Arial"),
+            Button("OK"),
+        ]
+        form = FlexForm("Replace Fonts in Family", components)
+        form.show()
+        if not form.values:
+            return
+
+        selected_font = form.values["font"]
+        output.print_md(
+            "# Updating fonts in current family to: **{}**".format(selected_font)
+        )
+
+        # The current document is a family document
+        result, found = process_family_document(doc, selected_font)
+
+        if found:
+            output.print_md("## Updated Types:")
+            for r in result:
+                output.print_md(
+                    "- Updated **{}**: from *{}* to **{}**".format(r[0], r[1], r[2])
+                )
+            output.print_md("\n**Total types updated: {}**".format(len(result)))
+            alert("Fonts updated successfully.", title="Success")
+        else:
+            alert(
+                "No text or dimension types with fonts found to update.",
+                title="Information",
+            )
+        return  # End script execution for family document
+
+    # --- LOGIC FOR PROJECT DOCUMENT ---
     components = [
-        Label(
-            "Change all text fonts in the project to a new font. This will update all text fonts in families, dimensions and text notes. This will not update fonts in schedules or tags."
-        ),
+        Label("Change all text fonts in the project to a new font."),
+        Label("This will update all text fonts in families, dimensions,"),
+        Label("and text notes. This will NOT update fonts in"),
+        Label("schedules or tags."),
         Separator(),
         Label("Pick Target Font:"),
         ComboBox("font", options=font_names, default="Arial"),

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Replace_Fonts.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Replace_Fonts.pushbutton/script.py
@@ -80,15 +80,12 @@ def update_nested_generic_annotations(host_family_doc, font_name):
             and f.FamilyCategory.Id.IntegerValue
             == int(DB.BuiltInCategory.OST_GenericAnnotation)
         ]
-  
-
     for nested_family in nested_families:
         if not nested_family.IsEditable:
             continue
-        nested_family_doc = None 
+        nested_family_doc = None
         try:
             nested_family_doc = host_family_doc.EditFamily(nested_family)
-
             found_in_this_nested = False
 
             # Update text types within this nested family
@@ -108,7 +105,6 @@ def update_nested_generic_annotations(host_family_doc, font_name):
                             rename_element_type_if_needed(et, old_font, font_name)
                             param.Set(font_name)
                             found_in_this_nested = True
-                            # Report the name of the type that was changed
                             results.append(
                                 (DB.Element.Name.GetValue(et), old_font, font_name)
                             )
@@ -126,17 +122,18 @@ def update_nested_generic_annotations(host_family_doc, font_name):
                 # Load the updated nested family back into its host family
                 nested_family_doc.LoadFamily(host_family_doc, FamilyLoaderOptionsHandler())
 
-            nested_family_doc.Close(False)
         except Exception as e:
             logger.error(
                 "Error processing nested family '{}' in '{}': {}".format(
                     nested_family.Name, host_family_doc.Title, e
                 )
             )
-            continue
         finally:
-            if nested_family_doc:
-                nested_family_doc.Close(False)
+            if nested_family_doc is not None:
+                try:
+                    nested_family_doc.Close(False)
+                except:
+                    pass
 
     return results, found_in_any_nested
 


### PR DESCRIPTION
## Description

- Added regex support for case-insensitive font name replacement.
- Implemented recursive updates for nested generic annotation families.
- Improved error handling and logging during font updates.
- Updated main script logic to handle font replacement in both family and project documents.

thanks to https://discourse.pyrevitlabs.io/u/denver-22 🚀 

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

https://discourse.pyrevitlabs.io/t/font-replacement-suggested-changes/9216

