### PR TITLE
Fix typo in failure processing log message

### DIFF
--- a/pyrevitlib/pyrevit/revit/__init__.py
+++ b/pyrevitlib/pyrevit/revit/__init__.py
@@ -162,7 +162,7 @@ class ErrorSwallower():
             mlogger.debug('setting failure processing results to: %s', result)
             event_args.SetProcessingResult(result)
         except Exception as fpex:
-            mlogger.error('Error occured while processing failures. | %s', fpex)
+            mlogger.error('Error occurred while processing failures. | %s', fpex)
 
     def get_swallowed_errors(self):
         """Return swallowed errors."""


### PR DESCRIPTION
## Summary
- fix spelling mistake in ErrorSwallower failure-processing log message

## Testing
- `pytest -q` *(fails: AttributeError: module 'collections' has no attribute 'MutableMapping')*

------
https://chatgpt.com/codex/tasks/task_b_6894ac9a7a58832caaf71f33ac3530d8