### PR TITLE
Fix config parser quoting logic for structured values

### DIFF
--- a/pyrevitlib/pyrevit/coreutils/configparser.py
+++ b/pyrevitlib/pyrevit/coreutils/configparser.py
@@ -52,9 +52,9 @@ class PyRevitConfigSectionParser(object):
                         # but is not encapsulated in quotes
                         # e.g. option = C:\Users\Desktop
                         value = value.strip()
-                        if not value.startswith('(') \
-                                or not value.startswith('[') \
-                                or not value.startswith('{'):
+                        if (not value.startswith('(')
+                                and not value.startswith('[')
+                                and not value.startswith('{')):
                             value = "\"%s\"" % value
                         return json.loads(value)  #pylint: disable=W0123
             except Exception:


### PR DESCRIPTION
## Summary
- fix conditional logic when checking if a config value is structured to avoid quoting lists or dicts

## Testing
- `python -m py_compile pyrevitlib/pyrevit/coreutils/configparser.py`
- `pytest pyrevitlib/pyrevit/unittests`


------
https://chatgpt.com/codex/tasks/task_b_6894a89fd894832c9bc38c70197b97ed