### PR TITLE
Update script.py

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Views.pulldown/Toggle Grid Bubbles by Direction.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Views.pulldown/Toggle Grid Bubbles by Direction.pushbutton/script.py
@@ -12,11 +12,12 @@ xamlfile = script.get_bundle_file("ui.xaml")
 
 VIEW_TYPES = [
     DB.ViewType.FloorPlan,
+	DB.ViewType.EngineeringPlan,
     DB.ViewType.Elevation,
     DB.ViewType.Section,
     DB.ViewType.CeilingPlan,
 ]
-PLAN_VIEWS = [DB.ViewType.FloorPlan, DB.ViewType.CeilingPlan]
+PLAN_VIEWS = [DB.ViewType.FloorPlan, DB.ViewType.CeilingPlan, DB.ViewType.EngineeringPlan]
 ELEVATION_VIEWS = [DB.ViewType.Elevation, DB.ViewType.Section]
 
 


### PR DESCRIPTION
## Description

Added DB.ViewType.EngineeringPlan as valid plan view.
The script works as intended but can't be used in EngineeringPlans. I have tested it after adding the EngineeringPlan as valid view and it works. I assume this viewtype was forgotten.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [ x] Changes are tested and verified to work as expected.

