### PR TITLE
Add .NET 8 Runtime Check to Installer Scripts

### DIFF
--- a/release/CodeDependencies.iss
+++ b/release/CodeDependencies.iss
@@ -1,0 +1,781 @@
+﻿[Code]
+// https://github.com/DomGries/InnoDependencyInstaller
+
+// types and variables
+type
+  TDependency_Entry = record
+    Filename: String;
+    Parameters: String;
+    Title: String;
+    URL: String;
+    Checksum: String;
+    ForceSuccess: Boolean;
+    RestartAfter: Boolean;
+  end;
+
+var
+  Dependency_Memo: String;
+  Dependency_List: array of TDependency_Entry;
+  Dependency_NeedToRestart, Dependency_ForceX86: Boolean;
+  Dependency_DownloadPage: TDownloadWizardPage;
+
+procedure Dependency_Add(const Filename, Parameters, Title, URL, Checksum: String; const ForceSuccess, RestartAfter: Boolean);
+var
+  Dependency: TDependency_Entry;
+  DependencyCount: Integer;
+begin
+  Dependency_Memo := Dependency_Memo + #13#10 + '%1' + Title;
+
+  Dependency.Filename := Filename;
+  Dependency.Parameters := Parameters;
+  Dependency.Title := Title;
+
+  if FileExists(ExpandConstant('{tmp}{\}') + Filename) then begin
+    Dependency.URL := '';
+  end else begin
+    Dependency.URL := URL;
+  end;
+
+  Dependency.Checksum := Checksum;
+  Dependency.ForceSuccess := ForceSuccess;
+  Dependency.RestartAfter := RestartAfter;
+
+  DependencyCount := GetArrayLength(Dependency_List);
+  SetArrayLength(Dependency_List, DependencyCount + 1);
+  Dependency_List[DependencyCount] := Dependency;
+end;
+
+<event('InitializeWizard')>
+procedure Dependency_InitializeWizard;
+begin
+  Dependency_DownloadPage := CreateDownloadPage(SetupMessage(msgWizardPreparing), SetupMessage(msgPreparingDesc), nil);
+end;
+
+<event('PrepareToInstall')>
+function Dependency_PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  DependencyCount, DependencyIndex, ResultCode: Integer;
+  Retry: Boolean;
+  TempValue: String;
+begin
+  DependencyCount := GetArrayLength(Dependency_List);
+
+  if DependencyCount > 0 then begin
+    Dependency_DownloadPage.Show;
+
+    for DependencyIndex := 0 to DependencyCount - 1 do begin
+      if Dependency_List[DependencyIndex].URL <> '' then begin
+        Dependency_DownloadPage.Clear;
+        Dependency_DownloadPage.Add(Dependency_List[DependencyIndex].URL, Dependency_List[DependencyIndex].Filename, Dependency_List[DependencyIndex].Checksum);
+
+        Retry := True;
+        while Retry do begin
+          Retry := False;
+
+          try
+            Dependency_DownloadPage.Download;
+          except
+            if Dependency_DownloadPage.AbortedByUser then begin
+              Result := Dependency_List[DependencyIndex].Title;
+              DependencyIndex := DependencyCount;
+            end else begin
+              case SuppressibleMsgBox(AddPeriod(GetExceptionMessage), mbError, MB_ABORTRETRYIGNORE, IDIGNORE) of
+                IDABORT: begin
+                  Result := Dependency_List[DependencyIndex].Title;
+                  DependencyIndex := DependencyCount;
+                end;
+                IDRETRY: begin
+                  Retry := True;
+                end;
+              end;
+            end;
+          end;
+        end;
+      end;
+    end;
+
+    if Result = '' then begin
+      for DependencyIndex := 0 to DependencyCount - 1 do begin
+        Dependency_DownloadPage.SetText(Dependency_List[DependencyIndex].Title, '');
+        Dependency_DownloadPage.SetProgress(DependencyIndex + 1, DependencyCount + 1);
+
+        while True do begin
+          ResultCode := 0;
+#ifdef Dependency_CustomExecute
+          if {#Dependency_CustomExecute}(ExpandConstant('{tmp}{\}') + Dependency_List[DependencyIndex].Filename, Dependency_List[DependencyIndex].Parameters, ResultCode) then begin
+#else
+          if ShellExec('', ExpandConstant('{tmp}{\}') + Dependency_List[DependencyIndex].Filename, Dependency_List[DependencyIndex].Parameters, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode) then begin
+#endif
+            if Dependency_List[DependencyIndex].RestartAfter then begin
+              if DependencyIndex = DependencyCount - 1 then begin
+                Dependency_NeedToRestart := True;
+              end else begin
+                NeedsRestart := True;
+                Result := Dependency_List[DependencyIndex].Title;
+              end;
+              break;
+            end else if (ResultCode = 0) or Dependency_List[DependencyIndex].ForceSuccess then begin // ERROR_SUCCESS (0)
+              break;
+            end else if ResultCode = 1641 then begin // ERROR_SUCCESS_REBOOT_INITIATED (1641)
+              NeedsRestart := True;
+              Result := Dependency_List[DependencyIndex].Title;
+              break;
+            end else if ResultCode = 3010 then begin // ERROR_SUCCESS_REBOOT_REQUIRED (3010)
+              Dependency_NeedToRestart := True;
+              break;
+            end;
+          end;
+
+          case SuppressibleMsgBox(FmtMessage(SetupMessage(msgErrorFunctionFailed), [Dependency_List[DependencyIndex].Title, IntToStr(ResultCode)]), mbError, MB_ABORTRETRYIGNORE, IDIGNORE) of
+            IDABORT: begin
+              Result := Dependency_List[DependencyIndex].Title;
+              break;
+            end;
+            IDIGNORE: begin
+              break;
+            end;
+          end;
+        end;
+
+        if Result <> '' then begin
+          break;
+        end;
+      end;
+
+      if NeedsRestart then begin
+        TempValue := '"' + ExpandConstant('{srcexe}') + '" /restart=1 /LANG="' + ExpandConstant('{language}') + '" /DIR="' + WizardDirValue + '" /GROUP="' + WizardGroupValue + '" /TYPE="' + WizardSetupType(False) + '" /COMPONENTS="' + WizardSelectedComponents(False) + '" /TASKS="' + WizardSelectedTasks(False) + '"';
+        if WizardNoIcons then begin
+          TempValue := TempValue + ' /NOICONS';
+        end;
+        RegWriteStringValue(HKA, 'SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce', '{#SetupSetting("AppName")}', TempValue);
+      end;
+    end;
+
+    Dependency_DownloadPage.Hide;
+  end;
+end;
+
+#ifndef Dependency_NoUpdateReadyMemo
+<event('UpdateReadyMemo')>
+#endif
+function Dependency_UpdateReadyMemo(const Space, NewLine, MemoUserInfoInfo, MemoDirInfo, MemoTypeInfo, MemoComponentsInfo, MemoGroupInfo, MemoTasksInfo: String): String;
+begin
+  Result := '';
+  if MemoUserInfoInfo <> '' then begin
+    Result := Result + MemoUserInfoInfo + Newline + NewLine;
+  end;
+  if MemoDirInfo <> '' then begin
+    Result := Result + MemoDirInfo + Newline + NewLine;
+  end;
+  if MemoTypeInfo <> '' then begin
+    Result := Result + MemoTypeInfo + Newline + NewLine;
+  end;
+  if MemoComponentsInfo <> '' then begin
+    Result := Result + MemoComponentsInfo + Newline + NewLine;
+  end;
+  if MemoGroupInfo <> '' then begin
+    Result := Result + MemoGroupInfo + Newline + NewLine;
+  end;
+  if MemoTasksInfo <> '' then begin
+    Result := Result + MemoTasksInfo;
+  end;
+
+  if Dependency_Memo <> '' then begin
+    if MemoTasksInfo = '' then begin
+      Result := Result + SetupMessage(msgReadyMemoTasks);
+    end;
+    Result := Result + FmtMessage(Dependency_Memo, [Space]);
+  end;
+end;
+
+<event('NeedRestart')>
+function Dependency_NeedRestart: Boolean;
+begin
+  Result := Dependency_NeedToRestart;
+end;
+
+function Dependency_IsX64: Boolean;
+begin
+  Result := not Dependency_ForceX86 and Is64BitInstallMode;
+end;
+
+function Dependency_String(const x86, x64: String): String;
+begin
+  if Dependency_IsX64 then begin
+    Result := x64;
+  end else begin
+    Result := x86;
+  end;
+end;
+
+function Dependency_ArchSuffix: String;
+begin
+  Result := Dependency_String('', '_x64');
+end;
+
+function Dependency_ArchTitle: String;
+begin
+  Result := Dependency_String(' (x86)', ' (x64)');
+end;
+
+function Dependency_IsNetCoreInstalled(Runtime: String; Major, Minor, Revision: Word): Boolean;
+var
+  Path: String;
+  ResultCode: Integer;
+  Output: TExecOutput;
+  LineIndex: Integer;
+  LineParts: TArrayOfString;
+  PackedVersion: Int64;
+  LineMajor, LineMinor, LineRevision, LineBuild: Word;
+begin
+  if not RegQueryStringValue(HKLM32, 'SOFTWARE\dotnet\Setup\InstalledVersions\x' + Dependency_String('86', '64'), 'InstallLocation', Path) or not FileExists(Path + 'dotnet.exe') then begin
+    Path := ExpandConstant(Dependency_String('{commonpf32}', '{commonpf64}')) + '\dotnet\';
+  end;
+  if ExecAndCaptureOutput(Path + 'dotnet.exe', '--list-runtimes', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, Output) and (ResultCode = 0) then begin
+    for LineIndex := 0 to Length(Output.StdOut) - 1 do begin
+      LineParts := StringSplit(Trim(Output.StdOut[LineIndex]), [' '], stExcludeEmpty);
+
+      if (Length(LineParts) > 1) and (Lowercase(LineParts[0]) = Lowercase(Runtime)) and StrToVersion(LineParts[1], PackedVersion) then begin
+        UnpackVersionComponents(PackedVersion, LineMajor, LineMinor, LineRevision, LineBuild);
+
+        if (LineMajor = Major) and (LineMinor = Minor) and (LineRevision >= Revision) then begin
+          Result := True;
+          exit;
+        end;
+      end;
+    end;
+  end;
+  Result := False;
+end;
+
+procedure Dependency_AddDotNet35;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-framework/net35-sp1
+  if not IsDotNetInstalled(net35, 1) then begin
+    Dependency_Add('dotnetfx35.exe',
+      '/lang:enu /passive /norestart',
+      '.NET Framework 3.5 Service Pack 1',
+      'https://download.microsoft.com/download/2/0/E/20E90413-712F-438C-988E-FDAA79A8AC3D/dotnetfx35.exe',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet40;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-framework/net40
+  if not IsDotNetInstalled(net4full, 0) then begin
+    Dependency_Add('dotNetFx40_Full_setup.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Framework 4.0',
+      'https://download.microsoft.com/download/1/B/E/1BE39E79-7E39-46A3-96FF-047F95396215/dotNetFx40_Full_setup.exe',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet45;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-framework/net452
+  if not IsDotNetInstalled(net452, 0) then begin
+    Dependency_Add('dotnetfx45.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Framework 4.5.2',
+      'https://go.microsoft.com/fwlink/?LinkId=397707',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet46;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-framework/net462
+  if not IsDotNetInstalled(net462, 0) then begin
+    Dependency_Add('dotnetfx46.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Framework 4.6.2',
+      'https://go.microsoft.com/fwlink/?linkid=780596',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet47;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-framework/net472
+  if not IsDotNetInstalled(net472, 0) then begin
+    Dependency_Add('dotnetfx47.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Framework 4.7.2',
+      'https://go.microsoft.com/fwlink/?LinkId=863262',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet48;
+begin
+    // https://dotnet.microsoft.com/download/dotnet-framework/net48
+    if not IsDotNetInstalled(net48, 0) then begin
+      Dependency_Add('dotnetfx48.exe',
+        '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+        '.NET Framework 4.8',
+        'https://go.microsoft.com/fwlink/?LinkId=2085155',
+        '', False, False);
+    end;
+end;
+
+procedure Dependency_AddDotNet481;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-framework/net481
+  if not IsDotNetInstalled(net481, 0) then begin
+    Dependency_Add('dotnetfx481.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Framework 4.8.1',
+      'https://go.microsoft.com/fwlink/?LinkId=2203304',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddNetCore31;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-core/3.1
+  if not Dependency_IsNetCoreInstalled('Microsoft.NETCore.App', 3, 1, 32) then begin
+    Dependency_Add('netcore31' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Core Runtime 3.1.32' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/de4b3438-24a2-4d1d-a845-97355cf97b71/515abb880478b49f7c1bced8fbf07b16/dotnet-runtime-3.1.32-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/476eba79-f17f-49c8-a213-0f24a22cd026/37c02de81ff5b76ac57a5427462395f1/dotnet-runtime-3.1.32-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddNetCore31Asp;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-core/3.1
+  if not Dependency_IsNetCoreInstalled('Microsoft.AspNetCore.App', 3, 1, 32) then begin
+    Dependency_Add('netcore31asp' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      'ASP.NET Core Runtime 3.1.32' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/63b482d2-04b2-4dd4-baaf-d1e78de80738/40321091c872f4e77337b68fc61a5a07/aspnetcore-runtime-3.1.32-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/98910750-2644-472c-ab2b-17f315ccb953/c2a4c223ee11e2eec7d13744e7a45547/aspnetcore-runtime-3.1.32-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddNetCore31Desktop;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-core/3.1
+  if not Dependency_IsNetCoreInstalled('Microsoft.WindowsDesktop.App', 3, 1, 32) then begin
+    Dependency_Add('netcore31desktop' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Desktop Runtime 3.1.32' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/3f353d2c-0431-48c5-bdf6-fbbe8f901bb5/542a4af07c1df5136a98a1c2df6f3d62/windowsdesktop-runtime-3.1.32-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/b92958c6-ae36-4efa-aafe-569fced953a5/1654639ef3b20eb576174c1cc200f33a/windowsdesktop-runtime-3.1.32-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet50;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/5.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.NETCore.App', 5, 0, 17) then begin
+    Dependency_Add('dotnet50' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Runtime 5.0.17' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/54683c13-6b04-4d7d-b4d4-1f055b50ea43/e99048e2840d57040e8312058853a5b9/dotnet-runtime-5.0.17-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/a0832b5a-6900-442b-af79-6ffddddd6ba4/e2df0b25dd851ee0b38a86947dd0e42e/dotnet-runtime-5.0.17-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet50Asp;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/5.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.AspNetCore.App', 5, 0, 17) then begin
+    Dependency_Add('dotnet50asp' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      'ASP.NET Core Runtime 5.0.17' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/4bfa247d-321d-4b29-a34b-62320849059b/8df7a17d9aad4044efe9b5b1c423e82c/aspnetcore-runtime-5.0.17-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/3789ec90-2717-424f-8b9c-3adbbcea6c16/2085cc5ff077b8789ff938015392e406/aspnetcore-runtime-5.0.17-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet50Desktop;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/5.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.WindowsDesktop.App', 5, 0, 17) then begin
+    Dependency_Add('dotnet50desktop' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Desktop Runtime 5.0.17' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/b6fe5f2a-95f4-46f1-9824-f5994f10bc69/db5ec9b47ec877b5276f83a185fdb6a0/windowsdesktop-runtime-5.0.17-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/3aa4e942-42cd-4bf5-afe7-fc23bd9c69c5/64da54c8864e473c19a7d3de15790418/windowsdesktop-runtime-5.0.17-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet60;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/6.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.NETCore.App', 6, 0, 36) then begin
+    Dependency_Add('dotnet60' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Runtime 6.0.36' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/727d79cb-6a4c-4a6b-bd9e-af99ad62de0b/5cd3550f1589a2f1b3a240c745dd1023/dotnet-runtime-6.0.36-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/1a5fc50a-9222-4f33-8f73-3c78485a55c7/1cb55899b68fcb9d98d206ba56f28b66/dotnet-runtime-6.0.36-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet60Asp;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/6.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.AspNetCore.App', 6, 0, 36) then begin
+    Dependency_Add('dotnet60asp' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      'ASP.NET Core Runtime 6.0.36' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/8cfa7f46-88f2-4521-a2d8-59b827420344/447de18a48115ac0fe6f381f0528e7a5/aspnetcore-runtime-6.0.36-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/0f0ea01c-ef7c-4493-8960-d1e9269b718b/3f95c5bd383be65c2c3384e9fa984078/aspnetcore-runtime-6.0.36-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet60Desktop;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/6.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.WindowsDesktop.App', 6, 0, 36) then begin
+    Dependency_Add('dotnet60desktop' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Desktop Runtime 6.0.36' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/cdc314df-4a4c-4709-868d-b974f336f77f/acd5ab7637e456c8a3aa667661324f6d/windowsdesktop-runtime-6.0.36-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/f6b6c5dc-e02d-4738-9559-296e938dabcb/b66d365729359df8e8ea131197715076/windowsdesktop-runtime-6.0.36-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet70;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/7.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.NETCore.App', 7, 0, 20) then begin
+    Dependency_Add('dotnet70' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Runtime 7.0.20' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/b2e820bd-b591-43df-ab10-1eeb7998cc18/661ca79db4934c6247f5c7a809a62238/dotnet-runtime-7.0.20-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/be7eaed0-4e32-472b-b53e-b08ac3433a22/fc99a5977c57cbfb93b4afb401953818/dotnet-runtime-7.0.20-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet70Asp;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/7.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.AspNetCore.App', 7, 0, 20) then begin
+    Dependency_Add('dotnet70asp' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      'ASP.NET Core Runtime 7.0.20' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/d84ac38e-a248-4c8d-b1fe-4ee092d6b4b1/9f0bf370619ab3da8869e467827a6dc6/aspnetcore-runtime-7.0.20-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/10651a65-8afc-46e3-9287-fecb0e68504e/4c2bf0cdb44612f29d9b3f901098e13e/aspnetcore-runtime-7.0.20-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet70Desktop;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/7.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.WindowsDesktop.App', 7, 0, 20) then begin
+    Dependency_Add('dotnet70desktop' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Desktop Runtime 7.0.20' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/b840017b-c69f-4724-a152-11020a0039e6/b74aa12e4ee765a3387a7dcd4ba56187/windowsdesktop-runtime-7.0.20-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/08bbfe8f-812d-479f-803b-23ea0bffce47/c320e4b037f3e92ab7ea92c3d7ea3ca1/windowsdesktop-runtime-7.0.20-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+
+procedure Dependency_AddDotNet80;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/8.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.NETCore.App', 8, 0, 13) then begin
+    Dependency_Add('dotnet80' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Runtime 8.0.13' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/5bac19ad-0711-4eba-a5a3-5e818c5f2fdf/cdec118c18b8457fe4d3ff918f78b4bd/dotnet-runtime-8.0.13-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/9c2068f2-dd3e-46cb-a88d-3c2d35b5181f/9ce26210851b0720c5382c6cd056b126/dotnet-runtime-8.0.13-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet80Asp;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/8.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.AspNetCore.App', 8, 0, 13) then begin
+    Dependency_Add('dotnet80asp' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      'ASP.NET Core Runtime 8.0.13' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/b11da59f-561b-466b-bfa8-d2dfc9b5bf48/f8dce6a44fd7be61ff97fe4949e57015/aspnetcore-runtime-8.0.13-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/86b8931f-09f6-4fce-b546-8139350da0c4/d6a5f16bcf81e0b5e9a733b892b1240f/aspnetcore-runtime-8.0.13-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet80Desktop;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/8.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.WindowsDesktop.App', 8, 0, 13) then begin
+    Dependency_Add('dotnet80desktop' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Desktop Runtime 8.0.13' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/b1827c52-ec83-4b3e-8d24-f321276bcdea/812e8d5871111cdc02cc82209c7d45fd/windowsdesktop-runtime-8.0.13-win-x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/fc8c9dea-8180-4dad-bf1b-5f229cf47477/c3f0536639ab40f1470b6bad5e1b95b8/windowsdesktop-runtime-8.0.13-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet90;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/9.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.NETCore.App', 9, 0, 6) then begin
+    Dependency_Add('dotnet90' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Runtime 9.0.6' + Dependency_ArchTitle,
+      Dependency_String('https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.6/dotnet-runtime-9.0.6-win-x86.exe', 'https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.6/dotnet-runtime-9.0.6-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet90Asp;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/9.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.AspNetCore.App', 9, 0, 6) then begin
+    Dependency_Add('dotnet90asp' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      'ASP.NET Core Runtime 9.0.6' + Dependency_ArchTitle,
+      Dependency_String('https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.6/aspnetcore-runtime-9.0.6-win-x86.exe', 'https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.6/aspnetcore-runtime-9.0.6-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet90Desktop;
+begin
+  // https://dotnet.microsoft.com/download/dotnet/9.0
+  if not Dependency_IsNetCoreInstalled('Microsoft.WindowsDesktop.App', 9, 0, 6) then begin
+    Dependency_Add('dotnet90desktop' + Dependency_ArchSuffix + '.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Desktop Runtime 9.0.6' + Dependency_ArchTitle,
+      Dependency_String('https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.6/windowsdesktop-runtime-9.0.6-win-x86.exe', 'https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/9.0.6/windowsdesktop-runtime-9.0.6-win-x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddVC2005;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=26347
+  if not IsMsiProductInstalled(Dependency_String('{86C9D5AA-F00C-4921-B3F2-C60AF92E2844}', '{A8D19029-8E5C-4E22-8011-48070F9E796E}'), PackVersionComponents(8, 0, 61000, 0)) then begin
+    Dependency_Add('vcredist2005' + Dependency_ArchSuffix + '.exe',
+      '/q',
+      'Visual C++ 2005 Service Pack 1 Redistributable' + Dependency_ArchTitle,
+      Dependency_String('https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x86.EXE', 'https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x64.EXE'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddVC2008;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=26368
+  if not IsMsiProductInstalled(Dependency_String('{DE2C306F-A067-38EF-B86C-03DE4B0312F9}', '{FDA45DDF-8E17-336F-A3ED-356B7B7C688A}'), PackVersionComponents(9, 0, 30729, 6161)) then begin
+    Dependency_Add('vcredist2008' + Dependency_ArchSuffix + '.exe',
+      '/q',
+      'Visual C++ 2008 Service Pack 1 Redistributable' + Dependency_ArchTitle,
+      Dependency_String('https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe', 'https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddVC2010;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=26999
+  if not IsMsiProductInstalled(Dependency_String('{1F4F1D2A-D9DA-32CF-9909-48485DA06DD5}', '{5B75F761-BAC8-33BC-A381-464DDDD813A3}'), PackVersionComponents(10, 0, 40219, 0)) then begin
+    Dependency_Add('vcredist2010' + Dependency_ArchSuffix + '.exe',
+      '/passive /norestart',
+      'Visual C++ 2010 Service Pack 1 Redistributable' + Dependency_ArchTitle,
+      Dependency_String('https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe', 'https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddVC2012;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=30679
+  if not IsMsiProductInstalled(Dependency_String('{4121ED58-4BD9-3E7B-A8B5-9F8BAAE045B7}', '{EFA6AFA1-738E-3E00-8101-FD03B86B29D1}'), PackVersionComponents(11, 0, 61030, 0)) then begin
+    Dependency_Add('vcredist2012' + Dependency_ArchSuffix + '.exe',
+      '/passive /norestart',
+      'Visual C++ 2012 Update 4 Redistributable' + Dependency_ArchTitle,
+      Dependency_String('https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe', 'https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddVC2013;
+begin
+  // https://support.microsoft.com/en-us/help/4032938
+  if not IsMsiProductInstalled(Dependency_String('{B59F5BF1-67C8-3802-8E59-2CE551A39FC5}', '{20400CF0-DE7C-327E-9AE4-F0F38D9085F8}'), PackVersionComponents(12, 0, 40664, 0)) then begin
+    Dependency_Add('vcredist2013' + Dependency_ArchSuffix + '.exe',
+      '/passive /norestart',
+      'Visual C++ 2013 Update 5 Redistributable' + Dependency_ArchTitle,
+      Dependency_String('https://download.visualstudio.microsoft.com/download/pr/10912113/5da66ddebb0ad32ebd4b922fd82e8e25/vcredist_x86.exe', 'https://download.visualstudio.microsoft.com/download/pr/10912041/cee5d6bca2ddbcd039da727bf4acb48a/vcredist_x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddVC2015To2022;
+begin
+  // https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist
+  if not IsMsiProductInstalled(Dependency_String('{65E5BD06-6392-3027-8C26-853107D3CF1A}', '{36F68A90-239C-34DF-B58C-64B30153CE35}'), PackVersionComponents(14, 42, 34433, 0)) then begin
+    Dependency_Add('vcredist2022' + Dependency_ArchSuffix + '.exe',
+      '/passive /norestart',
+      'Visual C++ 2015-2022 Redistributable' + Dependency_ArchTitle,
+      Dependency_String('https://aka.ms/vs/17/release/vc_redist.x86.exe', 'https://aka.ms/vs/17/release/vc_redist.x64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDirectX;
+begin
+#ifdef Dependency_Files_DirectX
+  ExtractTemporaryFile('dxwebsetup.exe');
+#endif
+  // https://www.microsoft.com/en-us/download/details.aspx?id=35
+  Dependency_Add('dxwebsetup.exe',
+    '/q',
+    'DirectX Runtime',
+    'https://download.microsoft.com/download/1/7/1/1718CCC4-6315-4D8E-9543-8E28A4E18C4C/dxwebsetup.exe',
+    '', True, False);
+end;
+
+procedure Dependency_AddSql2008Express;
+var
+  Version: String;
+  PackedVersion: Int64;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=30438
+  if not RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL10_50.MSSQLSERVER\MSSQLServer\CurrentVersion', 'CurrentVersion', Version) or not StrToVersion(Version, PackedVersion) or (ComparePackedVersion(PackedVersion, PackVersionComponents(10, 50, 4000, 0)) < 0) then begin
+    Dependency_Add('sql2008express' + Dependency_ArchSuffix + '.exe',
+      '/QS /IACCEPTSQLSERVERLICENSETERMS /ACTION=INSTALL /FEATURES=SQL /INSTANCENAME=MSSQLSERVER',
+      'SQL Server 2008 R2 Service Pack 2 Express',
+      Dependency_String('https://download.microsoft.com/download/0/4/B/04BE03CD-EAF3-4797-9D8D-2E08E316C998/SQLEXPR32_x86_ENU.exe', 'https://download.microsoft.com/download/0/4/B/04BE03CD-EAF3-4797-9D8D-2E08E316C998/SQLEXPR_x64_ENU.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddSql2012Express;
+var
+  Version: String;
+  PackedVersion: Int64;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=56042
+  if not RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL11.MSSQLSERVER\MSSQLServer\CurrentVersion', 'CurrentVersion', Version) or not StrToVersion(Version, PackedVersion) or (ComparePackedVersion(PackedVersion, PackVersionComponents(11, 0, 7001, 0)) < 0) then begin
+    Dependency_Add('sql2012express' + Dependency_ArchSuffix + '.exe',
+      '/QS /IACCEPTSQLSERVERLICENSETERMS /ACTION=INSTALL /FEATURES=SQL /INSTANCENAME=MSSQLSERVER',
+      'SQL Server 2012 Service Pack 4 Express',
+      Dependency_String('https://download.microsoft.com/download/B/D/E/BDE8FAD6-33E5-44F6-B714-348F73E602B6/SQLEXPR32_x86_ENU.exe', 'https://download.microsoft.com/download/B/D/E/BDE8FAD6-33E5-44F6-B714-348F73E602B6/SQLEXPR_x64_ENU.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddSql2014Express;
+var
+  Version: String;
+  PackedVersion: Int64;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=57473
+  if not RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL12.MSSQLSERVER\MSSQLServer\CurrentVersion', 'CurrentVersion', Version) or not StrToVersion(Version, PackedVersion) or (ComparePackedVersion(PackedVersion, PackVersionComponents(12, 0, 6024, 0)) < 0) then begin
+    Dependency_Add('sql2014express' + Dependency_ArchSuffix + '.exe',
+      '/QS /IACCEPTSQLSERVERLICENSETERMS /ACTION=INSTALL /FEATURES=SQL /INSTANCENAME=MSSQLSERVER',
+      'SQL Server 2014 Service Pack 3 Express',
+      Dependency_String('https://download.microsoft.com/download/3/9/F/39F968FA-DEBB-4960-8F9E-0E7BB3035959/SQLEXPR32_x86_ENU.exe', 'https://download.microsoft.com/download/3/9/F/39F968FA-DEBB-4960-8F9E-0E7BB3035959/SQLEXPR_x64_ENU.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddSql2016Express;
+var
+  Version: String;
+  PackedVersion: Int64;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=103447
+  if not RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQLServer\CurrentVersion', 'CurrentVersion', Version) or not StrToVersion(Version, PackedVersion) or (ComparePackedVersion(PackedVersion, PackVersionComponents(13, 0, 6404, 1)) < 0) then begin
+    Dependency_Add('sql2016express' + Dependency_ArchSuffix + '.exe',
+      '/QS /IACCEPTSQLSERVERLICENSETERMS /ACTION=INSTALL /FEATURES=SQL /INSTANCENAME=MSSQLSERVER',
+      'SQL Server 2016 Service Pack 3 Express',
+      'https://download.microsoft.com/download/f/a/8/fa83d147-63d1-449c-b22d-5fef9bd5bb46/SQLServer2016-SSEI-Expr.exe',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddSql2017Express;
+var
+  Version: String;
+  PackedVersion: Int64;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=55994
+  if not RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL14.MSSQLSERVER\MSSQLServer\CurrentVersion', 'CurrentVersion', Version) or not StrToVersion(Version, PackedVersion) or (ComparePackedVersion(PackedVersion, PackVersionComponents(14, 0, 0, 0)) < 0) then begin
+    Dependency_Add('sql2017express' + Dependency_ArchSuffix + '.exe',
+      '/QS /IACCEPTSQLSERVERLICENSETERMS /ACTION=INSTALL /FEATURES=SQL /INSTANCENAME=MSSQLSERVER',
+      'SQL Server 2017 Express',
+      'https://download.microsoft.com/download/5/E/9/5E9B18CC-8FD5-467E-B5BF-BADE39C51F73/SQLServer2017-SSEI-Expr.exe',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddSql2019Express;
+var
+  Version: String;
+  PackedVersion: Int64;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=101064
+  if not RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQLServer\CurrentVersion', 'CurrentVersion', Version) or not StrToVersion(Version, PackedVersion) or (ComparePackedVersion(PackedVersion, PackVersionComponents(15, 0, 0, 0)) < 0) then begin
+    Dependency_Add('sql2019express' + Dependency_ArchSuffix + '.exe',
+      '/QS /IACCEPTSQLSERVERLICENSETERMS /ACTION=INSTALL /FEATURES=SQL /INSTANCENAME=MSSQLSERVER',
+      'SQL Server 2019 Express',
+      'https://download.microsoft.com/download/7/f/8/7f8a9c43-8c8a-4f7c-9f92-83c18d96b681/SQL2019-SSEI-Expr.exe',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddSql2022Express;
+var
+  Version: String;
+  PackedVersion: Int64;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=104781
+  if not RegQueryStringValue(HKLM, 'SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL16.MSSQLSERVER\MSSQLServer\CurrentVersion', 'CurrentVersion', Version) or not StrToVersion(Version, PackedVersion) or (ComparePackedVersion(PackedVersion, PackVersionComponents(16, 0, 1000, 6)) < 0) then begin
+    Dependency_Add('sql2022express' + Dependency_ArchSuffix + '.exe',
+      '/QS /IACCEPTSQLSERVERLICENSETERMS /ACTION=INSTALL /FEATURES=SQL /INSTANCENAME=MSSQLSERVER',
+      'SQL Server 2022 Express',
+      'https://go.microsoft.com/fwlink/p/?linkid=2216019',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddWebView2;
+begin
+  // https://developer.microsoft.com/en-us/microsoft-edge/webview2
+  if not RegValueExists(HKLM, Dependency_String('SOFTWARE', 'SOFTWARE\WOW6432Node') + '\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}', 'pv') then begin
+    Dependency_Add('MicrosoftEdgeWebview2Setup.exe',
+      '/silent /install',
+      'WebView2 Runtime',
+      'https://go.microsoft.com/fwlink/p/?LinkId=2124703',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddAccessDatabaseEngine2010;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=13255
+  if not RegKeyExists(HKLM, 'SOFTWARE\Microsoft\Office\14.0\Access Connectivity Engine\Engines\ACE') then begin
+    Dependency_Add('AccessDatabaseEngine2010' + Dependency_ArchSuffix + '.exe',
+      '/quiet',
+      'Microsoft Access Database Engine 2010' + Dependency_ArchTitle,
+      Dependency_String('https://download.microsoft.com/download/2/4/3/24375141-E08D-4803-AB0E-10F2E3A07AAA/AccessDatabaseEngine.exe', 'https://download.microsoft.com/download/2/4/3/24375141-E08D-4803-AB0E-10F2E3A07AAA/AccessDatabaseEngine_X64.exe'),
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddAccessDatabaseEngine2016;
+begin
+  // https://www.microsoft.com/en-us/download/details.aspx?id=54920
+  if not RegKeyExists(HKLM, 'SOFTWARE\Microsoft\Office\16.0\Access Connectivity Engine\Engines\ACE') then begin
+    Dependency_Add('AccessDatabaseEngine2016' + Dependency_ArchSuffix + '.exe',
+      '/quiet',
+      'Microsoft Access Database Engine 2016' + Dependency_ArchTitle,
+      Dependency_String('https://download.microsoft.com/download/3/5/C/35C84C36-661A-44E6-9324-8786B8DBE231/accessdatabaseengine.exe', 'https://download.microsoft.com/download/3/5/C/35C84C36-661A-44E6-9324-8786B8DBE231/accessdatabaseengine_X64.exe'),
+      '', False, False);
+  end;
+end;
+
+[Files]
+#ifdef Dependency_Path_DirectX
+Source: "{#Dependency_Path_DirectX}dxwebsetup.exe"; Flags: dontcopy noencryption
+#endif

--- a/release/pyrevit-admin.iss
+++ b/release/pyrevit-admin.iss
@@ -3,6 +3,7 @@
 #define MyAppVersion "5.2.0.25181"
 #define MyAppPublisher "pyRevitLabs"
 #define MyAppURL "pyrevitlabs.io"
+#include "CodeDependencies.iss"
 
 [Setup]
 ; App information
@@ -20,7 +21,6 @@ DefaultGroupName={#MyAppName}
 DisableDirPage=auto
 DisableStartupPrompt=yes
 DisableProgramGroupPage=yes
-ArchitecturesInstallIn64BitMode=x64
 ChangesEnvironment=yes
 ;     path
 DefaultDirName={autopf}\{#MyAppName}-Master
@@ -38,6 +38,7 @@ DisableWelcomePage=no
 WizardStyle=classic
 WizardImageFile=.\pyrevit.bmp
 WizardSmallImageFile=.\pyrevit-banner.bmp
+ArchitecturesInstallIn64BitMode=x64
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -87,124 +88,13 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden runascurrentuser
 
 [Code]
-const
-    REQUIRED_MAJOR_VERSION = 8;
-
-function GetMajorVersion(VersionStr: String): Integer;
-var
-    SeparatorPos, DashPos: Integer;
-    MajorStr: String;
+function InitializeSetup: Boolean;
 begin
-    Result := 0;
-    SeparatorPos := Pos('.', VersionStr);
-    if SeparatorPos > 0 then
-    begin
-        MajorStr := Copy(VersionStr, 1, SeparatorPos - 1);
-        // Handle preview/rc versions by checking for dash
-        DashPos := Pos('-', MajorStr);
-        if DashPos > 0 then
-            MajorStr := Copy(MajorStr, 1, DashPos - 1);
-        
-        // Validate that MajorStr contains only digits
-        if (Length(MajorStr) > 0) and (Length(MajorStr) <= 3) then
-        begin
-            try
-                Result := StrToInt(MajorStr);
-                // Additional validation: major version should be reasonable (1-99)
-                if (Result < 1) or (Result > 99) then
-                begin
-                    Log('Warning: Invalid major version number: ' + MajorStr + ' from version: ' + VersionStr);
-                    Result := 0;
-                end;
-            except
-                on E: Exception do
-                begin
-                    Log('Error parsing major version from "' + MajorStr + '" in version "' + VersionStr + '": ' + E.Message);
-                    Result := 0;
-                end;
-            end;
-        end
-        else
-        begin
-            Log('Warning: Invalid major version format: "' + MajorStr + '" from version: "' + VersionStr + '"');
-            Result := 0;
-        end;
-    end
-    else
-    begin
-        Log('Warning: No dot separator found in version string: "' + VersionStr + '"');
-    end;
-end;
-
-function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
-var
-    FindRec: TFindRec;
-    Version: String;
-    Major: Integer;
-begin
-    Result := False;
-    if DirExists(Path) then
-    begin
-        if FindFirst(Path + '\*', FindRec) then
-        begin
-            try
-                repeat
-                    if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
-                    begin
-                        Version := FindRec.Name;
-                        Major := GetMajorVersion(Version);
-                        if Major >= REQUIRED_MAJOR_VERSION then
-                        begin
-                            FoundVersion := Version;
-                            Result := True;
-                            Exit;
-                        end;
-                    end;
-                until not FindNext(FindRec);
-            finally
-                FindClose(FindRec);
-            end;
-        end;
-    end;
-end;
-
-procedure GetDotNetDesktopRuntimeInfo(var Found: Boolean; var Version: String; var Path: String);
-var
-    PathX64, PathX86: String;
-begin
-    PathX64 := ExpandConstant('{pf64}\dotnet\shared\Microsoft.WindowsDesktop.App');
-    PathX86 := ExpandConstant('{pf32}\dotnet\shared\Microsoft.WindowsDesktop.App');
-
-    Found := CheckForDotNetRuntime(PathX64, Version);
-    if Found then
-    begin
-      Path := PathX64;
-      Exit;
-    end;
-
-    Found := CheckForDotNetRuntime(PathX86, Version);
-    if Found then
-    begin
-      Path := PathX86;
-      Exit;
-    end;
-end;
-
-procedure InitializeWizard();
-var
-    IsInstalled: Boolean;
-    FoundVersion, FoundPath: String;
-    MsgResult: Integer;
-    ErrorCode: Integer;
-begin
-    GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
-    if not IsInstalled then
-    begin
-        MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
-        if MsgResult = IDOK then
-        begin
-            Exec('cmd', '/c start https://dotnet.microsoft.com/en-us/download/dotnet/8.0', '', SW_HIDE, ewNoWait, ErrorCode);
-        end;
-        Abort;
-    end;
+  Dependency_AddDotNet80;
+  //Dependency_AddDotNet80Asp;
+  Dependency_AddDotNet80Desktop;
+  //Dependency_AddDotNet90;
+  //Dependency_AddDotNet90Asp;
+  //Dependency_AddDotNet90Desktop;
+  Result := True;
 end;

--- a/release/pyrevit-admin.iss
+++ b/release/pyrevit-admin.iss
@@ -90,12 +90,33 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detac
 const
     REQUIRED_MAJOR_VERSION = 8;
 
+function GetMajorVersion(VersionStr: String): Integer;
+var
+    SeparatorPos, DashPos: Integer;
+    MajorStr: String;
+begin
+    Result := 0;
+    SeparatorPos := Pos('.', VersionStr);
+    if SeparatorPos > 0 then
+    begin
+        MajorStr := Copy(VersionStr, 1, SeparatorPos - 1);
+        // Handle preview/rc versions by checking for dash
+        DashPos := Pos('-', MajorStr);
+        if DashPos > 0 then
+            MajorStr := Copy(MajorStr, 1, DashPos - 1);
+        try
+            Result := StrToInt(MajorStr);
+        except
+            Result := 0; // Invalid version
+        end;
+    end;
+end;
+
 function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
 var
     FindRec: TFindRec;
     Version: String;
     Major: Integer;
-    SeparatorPos: Integer;
 begin
     Result := False;
     if DirExists(Path) then
@@ -107,19 +128,12 @@ begin
                     if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
                     begin
                         Version := FindRec.Name;
-                        SeparatorPos := Pos('.', Version);
-                        if SeparatorPos > 0 then
+                        Major := GetMajorVersion(Version);
+                        if Major >= REQUIRED_MAJOR_VERSION then
                         begin
-                            try
-                                Major := StrToInt(Copy(Version, 1, SeparatorPos - 1));
-                                if Major >= REQUIRED_MAJOR_VERSION then
-                                begin
-                                    FoundVersion := Version;
-                                    Result := True;
-                                    Exit;
-                                end;
-                            except
-                            end;
+                            FoundVersion := Version;
+                            Result := True;
+                            Exit;
                         end;
                     end;
                 until not FindNext(FindRec);
@@ -160,11 +174,7 @@ var
     ErrorCode: Integer;
 begin
     GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
-    if IsInstalled then
-    begin
-        // Continue silently with installation
-    end
-    else
+    if not IsInstalled then
     begin
         MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
         if MsgResult = IDOK then

--- a/release/pyrevit-admin.iss
+++ b/release/pyrevit-admin.iss
@@ -91,10 +91,6 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detac
 function InitializeSetup: Boolean;
 begin
   Dependency_AddDotNet80;
-  //Dependency_AddDotNet80Asp;
   Dependency_AddDotNet80Desktop;
-  //Dependency_AddDotNet90;
-  //Dependency_AddDotNet90Asp;
-  //Dependency_AddDotNet90Desktop;
   Result := True;
 end;

--- a/release/pyrevit-admin.iss
+++ b/release/pyrevit-admin.iss
@@ -85,3 +85,92 @@ Filename: "{app}\bin\pyrevit.exe"; Description: "Attaching this clone..."; Param
 [UninstallRun]
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches clear --all"; Flags: runhidden runascurrentuser
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden runascurrentuser
+
+[Code]
+const
+    REQUIRED_MAJOR_VERSION = 8;
+
+function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
+var
+    FindRec: TFindRec;
+    Version: String;
+    Major: Integer;
+    SeparatorPos: Integer;
+begin
+    Result := False;
+    if DirExists(Path) then
+    begin
+        if FindFirst(Path + '\*', FindRec) then
+        begin
+            try
+                repeat
+                    if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
+                    begin
+                        Version := FindRec.Name;
+                        SeparatorPos := Pos('.', Version);
+                        if SeparatorPos > 0 then
+                        begin
+                            try
+                                Major := StrToInt(Copy(Version, 1, SeparatorPos - 1));
+                                if Major >= REQUIRED_MAJOR_VERSION then
+                                begin
+                                    FoundVersion := Version;
+                                    Result := True;
+                                    Exit;
+                                end;
+                            except
+                            end;
+                        end;
+                    end;
+                until not FindNext(FindRec);
+            finally
+                FindClose(FindRec);
+            end;
+        end;
+    end;
+end;
+
+procedure GetDotNetDesktopRuntimeInfo(var Found: Boolean; var Version: String; var Path: String);
+var
+    PathX64, PathX86: String;
+begin
+    PathX64 := ExpandConstant('{pf64}\dotnet\shared\Microsoft.WindowsDesktop.App');
+    PathX86 := ExpandConstant('{pf32}\dotnet\shared\Microsoft.WindowsDesktop.App');
+
+    Found := CheckForDotNetRuntime(PathX64, Version);
+    if Found then
+    begin
+      Path := PathX64;
+      Exit;
+    end;
+
+    Found := CheckForDotNetRuntime(PathX86, Version);
+    if Found then
+    begin
+      Path := PathX86;
+      Exit;
+    end;
+end;
+
+procedure InitializeWizard();
+var
+    IsInstalled: Boolean;
+    FoundVersion, FoundPath: String;
+    MsgResult: Integer;
+    ErrorCode: Integer;
+begin
+    GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
+    if IsInstalled then
+    begin
+        // Continue silently with installation
+    end
+    else
+    begin
+        MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
+        if MsgResult = IDOK then
+        begin
+            Exec('cmd', '/c start https://dotnet.microsoft.com/en-us/download/dotnet/8.0', '', SW_HIDE, ewNoWait, ErrorCode);
+        end;
+        Abort;
+    end;
+end;

--- a/release/pyrevit-admin.iss
+++ b/release/pyrevit-admin.iss
@@ -104,11 +104,35 @@ begin
         DashPos := Pos('-', MajorStr);
         if DashPos > 0 then
             MajorStr := Copy(MajorStr, 1, DashPos - 1);
-        try
-            Result := StrToInt(MajorStr);
-        except
-            Result := 0; // Invalid version
+        
+        // Validate that MajorStr contains only digits
+        if (Length(MajorStr) > 0) and (Length(MajorStr) <= 3) then
+        begin
+            try
+                Result := StrToInt(MajorStr);
+                // Additional validation: major version should be reasonable (1-99)
+                if (Result < 1) or (Result > 99) then
+                begin
+                    Log('Warning: Invalid major version number: ' + MajorStr + ' from version: ' + VersionStr);
+                    Result := 0;
+                end;
+            except
+                on E: Exception do
+                begin
+                    Log('Error parsing major version from "' + MajorStr + '" in version "' + VersionStr + '": ' + E.Message);
+                    Result := 0;
+                end;
+            end;
+        end
+        else
+        begin
+            Log('Warning: Invalid major version format: "' + MajorStr + '" from version: "' + VersionStr + '"');
+            Result := 0;
         end;
+    end
+    else
+    begin
+        Log('Warning: No dot separator found in version string: "' + VersionStr + '"');
     end;
 end;
 

--- a/release/pyrevit-cli-admin.iss
+++ b/release/pyrevit-cli-admin.iss
@@ -4,6 +4,7 @@
 #define MyAppPublisher "pyRevitLabs"
 #define MyAppURL "pyrevitlabs.io"
 #define MyAppExeName "pyrevit.exe"
+#include "CodeDependencies.iss"
 
 [Setup]
 ; App information
@@ -21,7 +22,6 @@ DefaultGroupName={#MyAppName}
 DisableDirPage=auto
 DisableStartupPrompt=yes
 DisableProgramGroupPage=yes
-ArchitecturesInstallIn64BitMode=x64
 ChangesEnvironment=yes
 ;     path
 DefaultDirName={autopf}\{#MyAppName}
@@ -39,6 +39,7 @@ DisableWelcomePage=no
 WizardStyle=classic
 WizardImageFile=.\pyrevit-cli.bmp
 WizardSmallImageFile=.\pyrevit-banner.bmp
+ArchitecturesInstallIn64BitMode=x64
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -63,124 +64,13 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden runascurrentuser
 
 [Code]
-const
-    REQUIRED_MAJOR_VERSION = 8;
-
-function GetMajorVersion(VersionStr: String): Integer;
-var
-    SeparatorPos, DashPos: Integer;
-    MajorStr: String;
+function InitializeSetup: Boolean;
 begin
-    Result := 0;
-    SeparatorPos := Pos('.', VersionStr);
-    if SeparatorPos > 0 then
-    begin
-        MajorStr := Copy(VersionStr, 1, SeparatorPos - 1);
-        // Handle preview/rc versions by checking for dash
-        DashPos := Pos('-', MajorStr);
-        if DashPos > 0 then
-            MajorStr := Copy(MajorStr, 1, DashPos - 1);
-        
-        // Validate that MajorStr contains only digits
-        if (Length(MajorStr) > 0) and (Length(MajorStr) <= 3) then
-        begin
-            try
-                Result := StrToInt(MajorStr);
-                // Additional validation: major version should be reasonable (1-99)
-                if (Result < 1) or (Result > 99) then
-                begin
-                    Log('Warning: Invalid major version number: ' + MajorStr + ' from version: ' + VersionStr);
-                    Result := 0;
-                end;
-            except
-                on E: Exception do
-                begin
-                    Log('Error parsing major version from "' + MajorStr + '" in version "' + VersionStr + '": ' + E.Message);
-                    Result := 0;
-                end;
-            end;
-        end
-        else
-        begin
-            Log('Warning: Invalid major version format: "' + MajorStr + '" from version: "' + VersionStr + '"');
-            Result := 0;
-        end;
-    end
-    else
-    begin
-        Log('Warning: No dot separator found in version string: "' + VersionStr + '"');
-    end;
-end;
-
-function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
-var
-    FindRec: TFindRec;
-    Version: String;
-    Major: Integer;
-begin
-    Result := False;
-    if DirExists(Path) then
-    begin
-        if FindFirst(Path + '\*', FindRec) then
-        begin
-            try
-                repeat
-                    if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
-                    begin
-                        Version := FindRec.Name;
-                        Major := GetMajorVersion(Version);
-                        if Major >= REQUIRED_MAJOR_VERSION then
-                        begin
-                            FoundVersion := Version;
-                            Result := True;
-                            Exit;
-                        end;
-                    end;
-                until not FindNext(FindRec);
-            finally
-                FindClose(FindRec);
-            end;
-        end;
-    end;
-end;
-
-procedure GetDotNetDesktopRuntimeInfo(var Found: Boolean; var Version: String; var Path: String);
-var
-    PathX64, PathX86: String;
-begin
-    PathX64 := ExpandConstant('{pf64}\dotnet\shared\Microsoft.WindowsDesktop.App');
-    PathX86 := ExpandConstant('{pf32}\dotnet\shared\Microsoft.WindowsDesktop.App');
-
-    Found := CheckForDotNetRuntime(PathX64, Version);
-    if Found then
-    begin
-      Path := PathX64;
-      Exit;
-    end;
-
-    Found := CheckForDotNetRuntime(PathX86, Version);
-    if Found then
-    begin
-      Path := PathX86;
-      Exit;
-    end;
-end;
-
-procedure InitializeWizard();
-var
-    IsInstalled: Boolean;
-    FoundVersion, FoundPath: String;
-    MsgResult: Integer;
-    ErrorCode: Integer;
-begin
-    GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
-    if not IsInstalled then
-    begin
-        MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
-        if MsgResult = IDOK then
-        begin
-            Exec('cmd', '/c start https://dotnet.microsoft.com/en-us/download/dotnet/8.0', '', SW_HIDE, ewNoWait, ErrorCode);
-        end;
-        Abort;
-    end;
+  Dependency_AddDotNet80;
+  //Dependency_AddDotNet80Asp;
+  Dependency_AddDotNet80Desktop;
+  //Dependency_AddDotNet90;
+  //Dependency_AddDotNet90Asp;
+  //Dependency_AddDotNet90Desktop;
+  Result := True;
 end;

--- a/release/pyrevit-cli-admin.iss
+++ b/release/pyrevit-cli-admin.iss
@@ -67,10 +67,6 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detac
 function InitializeSetup: Boolean;
 begin
   Dependency_AddDotNet80;
-  //Dependency_AddDotNet80Asp;
   Dependency_AddDotNet80Desktop;
-  //Dependency_AddDotNet90;
-  //Dependency_AddDotNet90Asp;
-  //Dependency_AddDotNet90Desktop;
   Result := True;
 end;

--- a/release/pyrevit-cli-admin.iss
+++ b/release/pyrevit-cli-admin.iss
@@ -80,11 +80,35 @@ begin
         DashPos := Pos('-', MajorStr);
         if DashPos > 0 then
             MajorStr := Copy(MajorStr, 1, DashPos - 1);
-        try
-            Result := StrToInt(MajorStr);
-        except
-            Result := 0; // Invalid version
+        
+        // Validate that MajorStr contains only digits
+        if (Length(MajorStr) > 0) and (Length(MajorStr) <= 3) then
+        begin
+            try
+                Result := StrToInt(MajorStr);
+                // Additional validation: major version should be reasonable (1-99)
+                if (Result < 1) or (Result > 99) then
+                begin
+                    Log('Warning: Invalid major version number: ' + MajorStr + ' from version: ' + VersionStr);
+                    Result := 0;
+                end;
+            except
+                on E: Exception do
+                begin
+                    Log('Error parsing major version from "' + MajorStr + '" in version "' + VersionStr + '": ' + E.Message);
+                    Result := 0;
+                end;
+            end;
+        end
+        else
+        begin
+            Log('Warning: Invalid major version format: "' + MajorStr + '" from version: "' + VersionStr + '"');
+            Result := 0;
         end;
+    end
+    else
+    begin
+        Log('Warning: No dot separator found in version string: "' + VersionStr + '"');
     end;
 end;
 

--- a/release/pyrevit-cli.iss
+++ b/release/pyrevit-cli.iss
@@ -4,6 +4,7 @@
 #define MyAppPublisher "pyRevitLabs"
 #define MyAppURL "pyrevitlabs.io"
 #define MyAppExeName "pyrevit.exe"
+#include "CodeDependencies.iss"
 
 [Setup]
 ; App information
@@ -21,7 +22,6 @@ DefaultGroupName={#MyAppName}
 DisableDirPage=auto
 DisableStartupPrompt=yes
 DisableProgramGroupPage=yes
-ArchitecturesInstallIn64BitMode=x64
 ChangesEnvironment=yes
 ;     path
 DefaultDirName={autopf}\{#MyAppName}
@@ -39,6 +39,7 @@ DisableWelcomePage=no
 WizardStyle=classic
 WizardImageFile=.\pyrevit-cli.bmp
 WizardSmallImageFile=.\pyrevit-banner.bmp
+ArchitecturesInstallIn64BitMode=x64
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -63,124 +64,13 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden
 
 [Code]
-const
-    REQUIRED_MAJOR_VERSION = 8;
-
-function GetMajorVersion(VersionStr: String): Integer;
-var
-    SeparatorPos, DashPos: Integer;
-    MajorStr: String;
+function InitializeSetup: Boolean;
 begin
-    Result := 0;
-    SeparatorPos := Pos('.', VersionStr);
-    if SeparatorPos > 0 then
-    begin
-        MajorStr := Copy(VersionStr, 1, SeparatorPos - 1);
-        // Handle preview/rc versions by checking for dash
-        DashPos := Pos('-', MajorStr);
-        if DashPos > 0 then
-            MajorStr := Copy(MajorStr, 1, DashPos - 1);
-        
-        // Validate that MajorStr contains only digits
-        if (Length(MajorStr) > 0) and (Length(MajorStr) <= 3) then
-        begin
-            try
-                Result := StrToInt(MajorStr);
-                // Additional validation: major version should be reasonable (1-99)
-                if (Result < 1) or (Result > 99) then
-                begin
-                    Log('Warning: Invalid major version number: ' + MajorStr + ' from version: ' + VersionStr);
-                    Result := 0;
-                end;
-            except
-                on E: Exception do
-                begin
-                    Log('Error parsing major version from "' + MajorStr + '" in version "' + VersionStr + '": ' + E.Message);
-                    Result := 0;
-                end;
-            end;
-        end
-        else
-        begin
-            Log('Warning: Invalid major version format: "' + MajorStr + '" from version: "' + VersionStr + '"');
-            Result := 0;
-        end;
-    end
-    else
-    begin
-        Log('Warning: No dot separator found in version string: "' + VersionStr + '"');
-    end;
-end;
-
-function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
-var
-    FindRec: TFindRec;
-    Version: String;
-    Major: Integer;
-begin
-    Result := False;
-    if DirExists(Path) then
-    begin
-        if FindFirst(Path + '\*', FindRec) then
-        begin
-            try
-                repeat
-                    if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
-                    begin
-                        Version := FindRec.Name;
-                        Major := GetMajorVersion(Version);
-                        if Major >= REQUIRED_MAJOR_VERSION then
-                        begin
-                            FoundVersion := Version;
-                            Result := True;
-                            Exit;
-                        end;
-                    end;
-                until not FindNext(FindRec);
-            finally
-                FindClose(FindRec);
-            end;
-        end;
-    end;
-end;
-
-procedure GetDotNetDesktopRuntimeInfo(var Found: Boolean; var Version: String; var Path: String);
-var
-    PathX64, PathX86: String;
-begin
-    PathX64 := ExpandConstant('{pf64}\dotnet\shared\Microsoft.WindowsDesktop.App');
-    PathX86 := ExpandConstant('{pf32}\dotnet\shared\Microsoft.WindowsDesktop.App');
-
-    Found := CheckForDotNetRuntime(PathX64, Version);
-    if Found then
-    begin
-      Path := PathX64;
-      Exit;
-    end;
-
-    Found := CheckForDotNetRuntime(PathX86, Version);
-    if Found then
-    begin
-      Path := PathX86;
-      Exit;
-    end;
-end;
-
-procedure InitializeWizard();
-var
-    IsInstalled: Boolean;
-    FoundVersion, FoundPath: String;
-    MsgResult: Integer;
-    ErrorCode: Integer;
-begin
-    GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
-    if not IsInstalled then
-    begin
-        MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
-        if MsgResult = IDOK then
-        begin
-            Exec('cmd', '/c start https://dotnet.microsoft.com/en-us/download/dotnet/8.0', '', SW_HIDE, ewNoWait, ErrorCode);
-        end;
-        Abort;
-    end;
+  Dependency_AddDotNet80;
+  //Dependency_AddDotNet80Asp;
+  Dependency_AddDotNet80Desktop;
+  //Dependency_AddDotNet90;
+  //Dependency_AddDotNet90Asp;
+  //Dependency_AddDotNet90Desktop;
+  Result := True;
 end;

--- a/release/pyrevit-cli.iss
+++ b/release/pyrevit-cli.iss
@@ -61,3 +61,92 @@ Filename: "{app}\bin\pyrevit.exe"; Description: "Detach existing clones..."; Par
 [UninstallRun]
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches clear --all"; Flags: runhidden
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden
+
+[Code]
+const
+    REQUIRED_MAJOR_VERSION = 8;
+
+function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
+var
+    FindRec: TFindRec;
+    Version: String;
+    Major: Integer;
+    SeparatorPos: Integer;
+begin
+    Result := False;
+    if DirExists(Path) then
+    begin
+        if FindFirst(Path + '\*', FindRec) then
+        begin
+            try
+                repeat
+                    if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
+                    begin
+                        Version := FindRec.Name;
+                        SeparatorPos := Pos('.', Version);
+                        if SeparatorPos > 0 then
+                        begin
+                            try
+                                Major := StrToInt(Copy(Version, 1, SeparatorPos - 1));
+                                if Major >= REQUIRED_MAJOR_VERSION then
+                                begin
+                                    FoundVersion := Version;
+                                    Result := True;
+                                    Exit;
+                                end;
+                            except
+                            end;
+                        end;
+                    end;
+                until not FindNext(FindRec);
+            finally
+                FindClose(FindRec);
+            end;
+        end;
+    end;
+end;
+
+procedure GetDotNetDesktopRuntimeInfo(var Found: Boolean; var Version: String; var Path: String);
+var
+    PathX64, PathX86: String;
+begin
+    PathX64 := ExpandConstant('{pf64}\dotnet\shared\Microsoft.WindowsDesktop.App');
+    PathX86 := ExpandConstant('{pf32}\dotnet\shared\Microsoft.WindowsDesktop.App');
+
+    Found := CheckForDotNetRuntime(PathX64, Version);
+    if Found then
+    begin
+      Path := PathX64;
+      Exit;
+    end;
+
+    Found := CheckForDotNetRuntime(PathX86, Version);
+    if Found then
+    begin
+      Path := PathX86;
+      Exit;
+    end;
+end;
+
+procedure InitializeWizard();
+var
+    IsInstalled: Boolean;
+    FoundVersion, FoundPath: String;
+    MsgResult: Integer;
+    ErrorCode: Integer;
+begin
+    GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
+    if IsInstalled then
+    begin
+        // Continue silently with installation
+    end
+    else
+    begin
+        MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
+        if MsgResult = IDOK then
+        begin
+            Exec('cmd', '/c start https://dotnet.microsoft.com/en-us/download/dotnet/8.0', '', SW_HIDE, ewNoWait, ErrorCode);
+        end;
+        Abort;
+    end;
+end;

--- a/release/pyrevit-cli.iss
+++ b/release/pyrevit-cli.iss
@@ -67,10 +67,6 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detac
 function InitializeSetup: Boolean;
 begin
   Dependency_AddDotNet80;
-  //Dependency_AddDotNet80Asp;
   Dependency_AddDotNet80Desktop;
-  //Dependency_AddDotNet90;
-  //Dependency_AddDotNet90Asp;
-  //Dependency_AddDotNet90Desktop;
   Result := True;
 end;

--- a/release/pyrevit-cli.iss
+++ b/release/pyrevit-cli.iss
@@ -80,11 +80,35 @@ begin
         DashPos := Pos('-', MajorStr);
         if DashPos > 0 then
             MajorStr := Copy(MajorStr, 1, DashPos - 1);
-        try
-            Result := StrToInt(MajorStr);
-        except
-            Result := 0; // Invalid version
+        
+        // Validate that MajorStr contains only digits
+        if (Length(MajorStr) > 0) and (Length(MajorStr) <= 3) then
+        begin
+            try
+                Result := StrToInt(MajorStr);
+                // Additional validation: major version should be reasonable (1-99)
+                if (Result < 1) or (Result > 99) then
+                begin
+                    Log('Warning: Invalid major version number: ' + MajorStr + ' from version: ' + VersionStr);
+                    Result := 0;
+                end;
+            except
+                on E: Exception do
+                begin
+                    Log('Error parsing major version from "' + MajorStr + '" in version "' + VersionStr + '": ' + E.Message);
+                    Result := 0;
+                end;
+            end;
+        end
+        else
+        begin
+            Log('Warning: Invalid major version format: "' + MajorStr + '" from version: "' + VersionStr + '"');
+            Result := 0;
         end;
+    end
+    else
+    begin
+        Log('Warning: No dot separator found in version string: "' + VersionStr + '"');
     end;
 end;
 

--- a/release/pyrevit.iss
+++ b/release/pyrevit.iss
@@ -3,6 +3,7 @@
 #define MyAppVersion "5.2.0.25181"
 #define MyAppPublisher "pyRevitLabs"
 #define MyAppURL "pyrevitlabs.io"
+#include "CodeDependencies.iss"
 
 [Setup]
 ; App information
@@ -20,7 +21,6 @@ DefaultGroupName={#MyAppName}
 DisableDirPage=auto
 DisableStartupPrompt=yes
 DisableProgramGroupPage=yes
-ArchitecturesInstallIn64BitMode=x64
 ChangesEnvironment=yes
 ;     path
 DefaultDirName={userappdata}\{#MyAppName}-Master
@@ -38,6 +38,7 @@ DisableWelcomePage=no
 WizardStyle=classic
 WizardImageFile=.\pyrevit.bmp
 WizardSmallImageFile=.\pyrevit-banner.bmp
+ArchitecturesInstallIn64BitMode=x64
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -87,124 +88,13 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden
 
 [Code]
-const
-    REQUIRED_MAJOR_VERSION = 8;
-
-function GetMajorVersion(VersionStr: String): Integer;
-var
-    SeparatorPos, DashPos: Integer;
-    MajorStr: String;
+function InitializeSetup: Boolean;
 begin
-    Result := 0;
-    SeparatorPos := Pos('.', VersionStr);
-    if SeparatorPos > 0 then
-    begin
-        MajorStr := Copy(VersionStr, 1, SeparatorPos - 1);
-        // Handle preview/rc versions by checking for dash
-        DashPos := Pos('-', MajorStr);
-        if DashPos > 0 then
-            MajorStr := Copy(MajorStr, 1, DashPos - 1);
-        
-        // Validate that MajorStr contains only digits
-        if (Length(MajorStr) > 0) and (Length(MajorStr) <= 3) then
-        begin
-            try
-                Result := StrToInt(MajorStr);
-                // Additional validation: major version should be reasonable (1-99)
-                if (Result < 1) or (Result > 99) then
-                begin
-                    Log('Warning: Invalid major version number: ' + MajorStr + ' from version: ' + VersionStr);
-                    Result := 0;
-                end;
-            except
-                on E: Exception do
-                begin
-                    Log('Error parsing major version from "' + MajorStr + '" in version "' + VersionStr + '": ' + E.Message);
-                    Result := 0;
-                end;
-            end;
-        end
-        else
-        begin
-            Log('Warning: Invalid major version format: "' + MajorStr + '" from version: "' + VersionStr + '"');
-            Result := 0;
-        end;
-    end
-    else
-    begin
-        Log('Warning: No dot separator found in version string: "' + VersionStr + '"');
-    end;
-end;
-
-function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
-var
-    FindRec: TFindRec;
-    Version: String;
-    Major: Integer;
-begin
-    Result := False;
-    if DirExists(Path) then
-    begin
-        if FindFirst(Path + '\*', FindRec) then
-        begin
-            try
-                repeat
-                    if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
-                    begin
-                        Version := FindRec.Name;
-                        Major := GetMajorVersion(Version);
-                        if Major >= REQUIRED_MAJOR_VERSION then
-                        begin
-                            FoundVersion := Version;
-                            Result := True;
-                            Exit;
-                        end;
-                    end;
-                until not FindNext(FindRec);
-            finally
-                FindClose(FindRec);
-            end;
-        end;
-    end;
-end;
-
-procedure GetDotNetDesktopRuntimeInfo(var Found: Boolean; var Version: String; var Path: String);
-var
-    PathX64, PathX86: String;
-begin
-    PathX64 := ExpandConstant('{pf64}\dotnet\shared\Microsoft.WindowsDesktop.App');
-    PathX86 := ExpandConstant('{pf32}\dotnet\shared\Microsoft.WindowsDesktop.App');
-
-    Found := CheckForDotNetRuntime(PathX64, Version);
-    if Found then
-    begin
-      Path := PathX64;
-      Exit;
-    end;
-
-    Found := CheckForDotNetRuntime(PathX86, Version);
-    if Found then
-    begin
-      Path := PathX86;
-      Exit;
-    end;
-end;
-
-procedure InitializeWizard();
-var
-    IsInstalled: Boolean;
-    FoundVersion, FoundPath: String;
-    MsgResult: Integer;
-    ErrorCode: Integer;
-begin
-    GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
-    if not IsInstalled then
-    begin
-        MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
-        if MsgResult = IDOK then
-        begin
-            Exec('cmd', '/c start https://dotnet.microsoft.com/en-us/download/dotnet/8.0', '', SW_HIDE, ewNoWait, ErrorCode);
-        end;
-        Abort;
-    end;
+  Dependency_AddDotNet80;
+  //Dependency_AddDotNet80Asp;
+  Dependency_AddDotNet80Desktop;
+  //Dependency_AddDotNet90;
+  //Dependency_AddDotNet90Asp;
+  //Dependency_AddDotNet90Desktop;
+  Result := True;
 end;

--- a/release/pyrevit.iss
+++ b/release/pyrevit.iss
@@ -90,12 +90,33 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detac
 const
     REQUIRED_MAJOR_VERSION = 8;
 
+function GetMajorVersion(VersionStr: String): Integer;
+var
+    SeparatorPos, DashPos: Integer;
+    MajorStr: String;
+begin
+    Result := 0;
+    SeparatorPos := Pos('.', VersionStr);
+    if SeparatorPos > 0 then
+    begin
+        MajorStr := Copy(VersionStr, 1, SeparatorPos - 1);
+        // Handle preview/rc versions by checking for dash
+        DashPos := Pos('-', MajorStr);
+        if DashPos > 0 then
+            MajorStr := Copy(MajorStr, 1, DashPos - 1);
+        try
+            Result := StrToInt(MajorStr);
+        except
+            Result := 0; // Invalid version
+        end;
+    end;
+end;
+
 function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
 var
     FindRec: TFindRec;
     Version: String;
     Major: Integer;
-    SeparatorPos: Integer;
 begin
     Result := False;
     if DirExists(Path) then
@@ -107,19 +128,12 @@ begin
                     if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
                     begin
                         Version := FindRec.Name;
-                        SeparatorPos := Pos('.', Version);
-                        if SeparatorPos > 0 then
+                        Major := GetMajorVersion(Version);
+                        if Major >= REQUIRED_MAJOR_VERSION then
                         begin
-                            try
-                                Major := StrToInt(Copy(Version, 1, SeparatorPos - 1));
-                                if Major >= REQUIRED_MAJOR_VERSION then
-                                begin
-                                    FoundVersion := Version;
-                                    Result := True;
-                                    Exit;
-                                end;
-                            except
-                            end;
+                            FoundVersion := Version;
+                            Result := True;
+                            Exit;
                         end;
                     end;
                 until not FindNext(FindRec);
@@ -160,11 +174,7 @@ var
     ErrorCode: Integer;
 begin
     GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
-    if IsInstalled then
-    begin
-        // Continue silently with installation
-    end
-    else
+    if not IsInstalled then
     begin
         MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
         if MsgResult = IDOK then

--- a/release/pyrevit.iss
+++ b/release/pyrevit.iss
@@ -91,10 +91,6 @@ Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detac
 function InitializeSetup: Boolean;
 begin
   Dependency_AddDotNet80;
-  //Dependency_AddDotNet80Asp;
   Dependency_AddDotNet80Desktop;
-  //Dependency_AddDotNet90;
-  //Dependency_AddDotNet90Asp;
-  //Dependency_AddDotNet90Desktop;
   Result := True;
 end;

--- a/release/pyrevit.iss
+++ b/release/pyrevit.iss
@@ -85,3 +85,92 @@ Filename: "{app}\bin\pyrevit.exe"; Description: "Attaching this clone..."; Param
 [UninstallRun]
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "ClearCaches"; Parameters: "caches clear --all"; Flags: runhidden
 Filename: "{app}\bin\pyrevit.exe"; RunOnceId: "DetachClones"; Parameters: "detach --all"; Flags: runhidden
+
+[Code]
+const
+    REQUIRED_MAJOR_VERSION = 8;
+
+function CheckForDotNetRuntime(Path: String; var FoundVersion: String): Boolean;
+var
+    FindRec: TFindRec;
+    Version: String;
+    Major: Integer;
+    SeparatorPos: Integer;
+begin
+    Result := False;
+    if DirExists(Path) then
+    begin
+        if FindFirst(Path + '\*', FindRec) then
+        begin
+            try
+                repeat
+                    if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY <> 0) and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
+                    begin
+                        Version := FindRec.Name;
+                        SeparatorPos := Pos('.', Version);
+                        if SeparatorPos > 0 then
+                        begin
+                            try
+                                Major := StrToInt(Copy(Version, 1, SeparatorPos - 1));
+                                if Major >= REQUIRED_MAJOR_VERSION then
+                                begin
+                                    FoundVersion := Version;
+                                    Result := True;
+                                    Exit;
+                                end;
+                            except
+                            end;
+                        end;
+                    end;
+                until not FindNext(FindRec);
+            finally
+                FindClose(FindRec);
+            end;
+        end;
+    end;
+end;
+
+procedure GetDotNetDesktopRuntimeInfo(var Found: Boolean; var Version: String; var Path: String);
+var
+    PathX64, PathX86: String;
+begin
+    PathX64 := ExpandConstant('{pf64}\dotnet\shared\Microsoft.WindowsDesktop.App');
+    PathX86 := ExpandConstant('{pf32}\dotnet\shared\Microsoft.WindowsDesktop.App');
+
+    Found := CheckForDotNetRuntime(PathX64, Version);
+    if Found then
+    begin
+      Path := PathX64;
+      Exit;
+    end;
+
+    Found := CheckForDotNetRuntime(PathX86, Version);
+    if Found then
+    begin
+      Path := PathX86;
+      Exit;
+    end;
+end;
+
+procedure InitializeWizard();
+var
+    IsInstalled: Boolean;
+    FoundVersion, FoundPath: String;
+    MsgResult: Integer;
+    ErrorCode: Integer;
+begin
+    GetDotNetDesktopRuntimeInfo(IsInstalled, FoundVersion, FoundPath);
+    if IsInstalled then
+    begin
+        // Continue silently with installation
+    end
+    else
+    begin
+        MsgResult := MsgBox('Could not find .NET 8 Runtime.'#13#10#13#10'Click OK to download .NET 8 Runtime from Microsoft, or Cancel to abort installation.', mbError, MB_OKCANCEL);
+        if MsgResult = IDOK then
+        begin
+            Exec('cmd', '/c start https://dotnet.microsoft.com/en-us/download/dotnet/8.0', '', SW_HIDE, ewNoWait, ErrorCode);
+        end;
+        Abort;
+    end;
+end;

--- a/release/pyrevit.iss
+++ b/release/pyrevit.iss
@@ -104,11 +104,35 @@ begin
         DashPos := Pos('-', MajorStr);
         if DashPos > 0 then
             MajorStr := Copy(MajorStr, 1, DashPos - 1);
-        try
-            Result := StrToInt(MajorStr);
-        except
-            Result := 0; // Invalid version
+        
+        // Validate that MajorStr contains only digits
+        if (Length(MajorStr) > 0) and (Length(MajorStr) <= 3) then
+        begin
+            try
+                Result := StrToInt(MajorStr);
+                // Additional validation: major version should be reasonable (1-99)
+                if (Result < 1) or (Result > 99) then
+                begin
+                    Log('Warning: Invalid major version number: ' + MajorStr + ' from version: ' + VersionStr);
+                    Result := 0;
+                end;
+            except
+                on E: Exception do
+                begin
+                    Log('Error parsing major version from "' + MajorStr + '" in version "' + VersionStr + '": ' + E.Message);
+                    Result := 0;
+                end;
+            end;
+        end
+        else
+        begin
+            Log('Warning: Invalid major version format: "' + MajorStr + '" from version: "' + VersionStr + '"');
+            Result := 0;
         end;
+    end
+    else
+    begin
+        Log('Warning: No dot separator found in version string: "' + VersionStr + '"');
     end;
 end;
 


### PR DESCRIPTION
## Description

Implemented a check for the .NET 8 Runtime in the installation scripts for pyRevit, pyRevit CLI, and pyRevit Admin. If the required runtime is not found, users are prompted to download it from the official Microsoft site. This ensures that the application has the necessary dependencies before proceeding with the installation.
Fixes [Bug]: Installer does not check for .NET "core" runtime #2730

---

- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2730

---

## Additional Notes

I could also have used the https://github.com/DomGries/InnoDependencyInstaller
but I did not want to had more dependencies to the tech stack

---

Thank you for contributing to pyRevit! 🎉
