### PR TITLE
compat: Revision API

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Revision.pulldown/Generate Revision Report.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Revision.pulldown/Generate Revision Report.pushbutton/script.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-"""Generates a report from all revisions in current project."""
-"""tooltip."""
 #pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
 from pyrevit import coreutils
 from pyrevit import revit, DB
@@ -19,7 +17,8 @@ all_sheets = sorted(sheetsnotsorted, key=lambda x: x.SheetNumber)
 # collect all clouds
 all_clouds = DB.FilteredElementCollector(revit.doc)\
                .OfCategory(DB.BuiltInCategory.OST_RevisionClouds)\
-               .WhereElementIsNotElementType()
+               .WhereElementIsNotElementType()\
+               .ToElements()
 
 # collect all revisions
 all_revisions = forms.select_revisions(
@@ -82,11 +81,12 @@ class RevisedSheet:
     def __init__(self, rvt_sheet):
         self._rvt_sheet = rvt_sheet
 
-        self._clouds = []
-        self._find_all_clouds()
-        self._find_all_revisions()
+        self._sheet_revisions = self._find_all_revisions_in_sheet()
+        self._sheet_clouds = self._find_all_clouds_in_sheet()
+        self._rev_numbers = self._find_revision_numbers()
 
-    def _find_all_clouds(self):
+    def _find_all_clouds_in_sheet(self):
+        sheet_clouds = []
         ownerview_ids = [self._rvt_sheet.Id]
         # add all the sheeted views to list
         ownerview_ids.extend(
@@ -94,20 +94,48 @@ class RevisedSheet:
                 revit.doc.GetElement(x).ViewId
                 for x in self._rvt_sheet.GetAllViewports()
             ])
-        for rev_cloud in all_clouds:
-            if rev_cloud.OwnerViewId in ownerview_ids:
-                self._clouds.append(rev_cloud)
 
-    def _find_all_revisions(self):
-        self._revisions = set([cloud.RevisionId for cloud in self._clouds])
-        self._revisions.update(
+        primary_owenerview_ids = [
+            revit.doc.GetElement(view_id).GetPrimaryViewId()
+            for view_id in ownerview_ids
+            if revit.doc.GetElement(view_id).GetPrimaryViewId() != DB.ElementId.InvalidElementId
+        ]
+
+        for rev_cloud in all_clouds:
+            is_rev_cloud_visible_in_sheet = self._is_revision_cloud_visible_in_sheet(rev_cloud)
+            is_rev_cloud_in_sheet_revisions = rev_cloud.RevisionId in self._sheet_revisions
+
+            if (is_rev_cloud_in_sheet_revisions and is_rev_cloud_visible_in_sheet and (
+                rev_cloud.OwnerViewId in ownerview_ids or rev_cloud.OwnerViewId in primary_owenerview_ids
+            )):
+                    sheet_clouds.append(rev_cloud)
+        return sheet_clouds
+
+    def _is_revision_cloud_visible_in_sheet(self, rev_cloud):
+        """Check if a revision cloud is visible in the sheet."""
+        is_visible = False
+        for view_id in self._rvt_sheet.GetAllViewports():
+            viewport = revit.doc.GetElement(view_id)
+            view = revit.doc.GetElement(viewport.ViewId)
+            if not rev_cloud.IsHidden(view):
+                is_visible = True
+                break
+        return is_visible
+
+    def _find_all_revisions_in_sheet(self):
+        revisions = set(self._rvt_sheet.GetAllRevisionIds())
+        revisions.update(
             set(self._rvt_sheet.GetAdditionalRevisionIds())
         )
-        self._rev_numbers = set(
+        return revisions
+
+    def _find_revision_numbers(self):
+        rev_numbers = set(
             [
                 revit.query.get_rev_number(revit.doc.GetElement(rev_id))
-                for rev_id in self._revisions
+                for rev_id in self._sheet_revisions
             ])
+        return rev_numbers
 
     @property
     def sheet_number(self):
@@ -119,28 +147,32 @@ class RevisedSheet:
 
     @property
     def cloud_count(self):
-        return len(self._clouds)
+        return len(self._sheet_clouds)
 
     @property
     def rev_count(self):
-        return len(self._revisions)
+        return len(self._sheet_revisions)
+
+    @property
+    def additional_revisions_count(self):
+        return len(set(self._rvt_sheet.GetAdditionalRevisionIds()))
 
     def get_clouds(self):
-        return self._clouds
+        return self._sheet_clouds
 
     def get_comments(self):
         all_comments = set()
-        for cloud in self._clouds:
+        for cloud in self._sheet_clouds:
             cparam = \
                 cloud.Parameter[DB.BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS]
             comment = cparam.AsString()
             if not coreutils.is_blank(comment):
                 all_comments.add(comment)
         return all_comments
-    
+
     def get_all_revision_marks(self):
         all_marks = set()
-        for cloud in self._clouds:
+        for cloud in self._sheet_clouds:
             cparam = \
                 cloud.Parameter[DB.BuiltInParameter.ALL_MODEL_MARK]
             mark = cparam.AsString()
@@ -206,6 +238,13 @@ for rev_sheet in revised_sheets:
                     rev_sheet.cloud_count,
                     coreutils.join_strings(rev_sheet.get_revision_numbers(),
                                            separator=',')))
+
+        if rev_sheet.additional_revisions_count > 0:
+            console.print_md(
+                'Additional Revisions Count: {} (revisions not associated with a cloud on this sheet)'
+                .format(rev_sheet.additional_revisions_count)
+            )
+
         comments = rev_sheet.get_comments()
         if comments:
             print('\t\tRevision comments:\n{}'

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Revision.pulldown/Generate Revision Report.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Revision.pulldown/Generate Revision Report.pushbutton/script.py
@@ -1,28 +1,31 @@
 # -*- coding: utf-8 -*-
-#pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
+# pylint: disable=import-error,invalid-name,broad-except,superfluous-parens
 from pyrevit import coreutils
 from pyrevit import revit, DB
 from pyrevit import script, forms
 
 
 # collect sheet
-sheetsnotsorted = DB.FilteredElementCollector(revit.doc)\
-                    .OfCategory(DB.BuiltInCategory.OST_Sheets)\
-                    .WhereElementIsNotElementType()\
-                    .ToElements()
+sheetsnotsorted = (
+    DB.FilteredElementCollector(revit.doc)
+    .OfCategory(DB.BuiltInCategory.OST_Sheets)
+    .WhereElementIsNotElementType()
+    .ToElements()
+)
 
 all_sheets = sorted(sheetsnotsorted, key=lambda x: x.SheetNumber)
 
-
 # collect all clouds
-all_clouds = DB.FilteredElementCollector(revit.doc)\
-               .OfCategory(DB.BuiltInCategory.OST_RevisionClouds)\
-               .WhereElementIsNotElementType()\
-               .ToElements()
+all_clouds = (
+    DB.FilteredElementCollector(revit.doc)
+    .OfCategory(DB.BuiltInCategory.OST_RevisionClouds)
+    .WhereElementIsNotElementType()
+    .ToElements()
+)
 
 # collect all revisions
 all_revisions = forms.select_revisions(
-                    title='Select Revisions To Include In The Report'
+    title="Select Revisions To Include In The Report"
 )
 if not all_revisions:
     script.exit()
@@ -31,47 +34,51 @@ console = script.get_output()
 console.set_height(800)
 console.lock_size()
 
-report_title = 'Revision Report'
+report_title = "Revision Report"
 report_date = coreutils.current_date()
 report_project = revit.query.get_project_info().name
 
 
 # setup element styling
 console.add_style(
-    'table { border-collapse: collapse; width:100% }'
-    'table, th, td { border-bottom: 1px solid #aaa; padding: 5px;}'
-    'th { background-color: #545454; color: white; }'
-    'tr:nth-child(odd) {background-color: #f2f2f2}'
-    )
+    "table { border-collapse: collapse; width:100% }"
+    "table, th, td { border-bottom: 1px solid #aaa; padding: 5px;}"
+    "th { background-color: #545454; color: white; }"
+    "tr:nth-child(odd) {background-color: #f2f2f2}"
+)
 
 
 # Print Title and Report Info
-console.print_md('# {}'.format(report_title))
-print('Project Name: {project}\nDate: {date}'
-      .format(project=report_project, date=report_date))
+console.print_md("# {}".format(report_title))
+print(
+    "Project Name: {project}\nDate: {date}".format(
+        project=report_project, date=report_date
+    )
+)
 console.insert_divider()
 
 # Print information about all existing revisions
-console.print_md('### List of Revisions')
+console.print_md("### List of Revisions")
 # prepare markdown code for the revision table
-rev_table_header = "| Number        | Date           | Description  |\n" \
-                   "|:-------------:|:--------------:|:-------------|\n"
+rev_table_header = (
+    "| Number        | Date           | Description  |\n"
+    "|:-------------:|:--------------:|:-------------|\n"
+)
 rev_table_template = "|{number}|{date}|{desc}|\n"
 rev_table = rev_table_header
 
 # gather revision number, date, and description in tuple list
-rev_data = [(revit.query.get_rev_number(rev),
-             rev.RevisionDate,
-             rev.Description) for rev in all_revisions]
+rev_data = [
+    (revit.query.get_rev_number(rev), rev.RevisionDate, rev.Description)
+    for rev in all_revisions
+]
 
 # sort tuple list by revision number
-rev_data.sort(key=lambda rev:rev[0])
+rev_data.sort(key=lambda rev: rev[0])
 
 # add revision data to the revision table string
 for rev in rev_data:
-    rev_table += rev_table_template.format(number=rev[0],
-                                           date=rev[1],
-                                           desc=rev[2])
+    rev_table += rev_table_template.format(number=rev[0], date=rev[1], desc=rev[2])
 
 # print revision table
 console.print_md(rev_table)
@@ -90,25 +97,33 @@ class RevisedSheet:
         ownerview_ids = [self._rvt_sheet.Id]
         # add all the sheeted views to list
         ownerview_ids.extend(
-            [
-                revit.doc.GetElement(x).ViewId
-                for x in self._rvt_sheet.GetAllViewports()
-            ])
+            [revit.doc.GetElement(x).ViewId for x in self._rvt_sheet.GetAllViewports()]
+        )
 
         primary_owenerview_ids = [
             revit.doc.GetElement(view_id).GetPrimaryViewId()
             for view_id in ownerview_ids
-            if revit.doc.GetElement(view_id).GetPrimaryViewId() != DB.ElementId.InvalidElementId
+            if revit.doc.GetElement(view_id).GetPrimaryViewId()
+            != DB.ElementId.InvalidElementId
         ]
 
         for rev_cloud in all_clouds:
-            is_rev_cloud_visible_in_sheet = self._is_revision_cloud_visible_in_sheet(rev_cloud)
-            is_rev_cloud_in_sheet_revisions = rev_cloud.RevisionId in self._sheet_revisions
+            is_rev_cloud_visible_in_sheet = self._is_revision_cloud_visible_in_sheet(
+                rev_cloud
+            )
+            is_rev_cloud_in_sheet_revisions = (
+                rev_cloud.RevisionId in self._sheet_revisions
+            )
 
-            if (is_rev_cloud_in_sheet_revisions and is_rev_cloud_visible_in_sheet and (
-                rev_cloud.OwnerViewId in ownerview_ids or rev_cloud.OwnerViewId in primary_owenerview_ids
-            )):
-                    sheet_clouds.append(rev_cloud)
+            if (
+                is_rev_cloud_in_sheet_revisions
+                and is_rev_cloud_visible_in_sheet
+                and (
+                    rev_cloud.OwnerViewId in ownerview_ids
+                    or rev_cloud.OwnerViewId in primary_owenerview_ids
+                )
+            ):
+                sheet_clouds.append(rev_cloud)
         return sheet_clouds
 
     def _is_revision_cloud_visible_in_sheet(self, rev_cloud):
@@ -124,9 +139,7 @@ class RevisedSheet:
 
     def _find_all_revisions_in_sheet(self):
         revisions = set(self._rvt_sheet.GetAllRevisionIds())
-        revisions.update(
-            set(self._rvt_sheet.GetAdditionalRevisionIds())
-        )
+        revisions.update(set(self._rvt_sheet.GetAdditionalRevisionIds()))
         return revisions
 
     def _find_revision_numbers(self):
@@ -134,7 +147,8 @@ class RevisedSheet:
             [
                 revit.query.get_rev_number(revit.doc.GetElement(rev_id))
                 for rev_id in self._sheet_revisions
-            ])
+            ]
+        )
         return rev_numbers
 
     @property
@@ -163,8 +177,7 @@ class RevisedSheet:
     def get_comments(self):
         all_comments = set()
         for cloud in self._sheet_clouds:
-            cparam = \
-                cloud.Parameter[DB.BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS]
+            cparam = cloud.Parameter[DB.BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS]
             comment = cparam.AsString()
             if not coreutils.is_blank(comment):
                 all_comments.add(comment)
@@ -173,8 +186,7 @@ class RevisedSheet:
     def get_all_revision_marks(self):
         all_marks = set()
         for cloud in self._sheet_clouds:
-            cparam = \
-                cloud.Parameter[DB.BuiltInParameter.ALL_MODEL_MARK]
+            cparam = cloud.Parameter[DB.BuiltInParameter.ALL_MODEL_MARK]
             mark = cparam.AsString()
             if not coreutils.is_blank(mark):
                 all_marks.add(mark)
@@ -192,35 +204,29 @@ for sheet in all_sheets:
 
 # draw a revision chart
 chart = console.make_bar_chart()
-chart.options.scales = {'type': 'linear',
-                        'yAxes': [
-                            {
-                                # 'stacked': True,
-                                'ticks': {'min': 0, 'stepSize': 1}
-                            }
-                            ],
-                        'xAxes': [
-                            {
-                                'ticks': {'minRotation': 90}
-                            }
-                            ]}
+chart.options.scales = {
+    "type": "linear",
+    "yAxes": [
+        {
+            # 'stacked': True,
+            "ticks": {"min": 0, "stepSize": 1}
+        }
+    ],
+    "xAxes": [{"ticks": {"minRotation": 90}}],
+}
 
-chart.data.labels = [rs.sheet_number
-                     for rs in revised_sheets
-                     if rs.rev_count > 0]
+chart.data.labels = [rs.sheet_number for rs in revised_sheets if rs.rev_count > 0]
 chart.set_height(100)
 
-cloudcount_dataset = chart.data.new_dataset('Revision Count')
-cloudcount_dataset.set_color('red')
-cloudcount_dataset.data = [rs.rev_count
-                           for rs in revised_sheets
-                           if rs.rev_count > 0]
+cloudcount_dataset = chart.data.new_dataset("Revision Count")
+cloudcount_dataset.set_color("red")
+cloudcount_dataset.data = [rs.rev_count for rs in revised_sheets if rs.rev_count > 0]
 
-cloudcount_dataset = chart.data.new_dataset('Revision Cloud Count')
-cloudcount_dataset.set_color('black')
-cloudcount_dataset.data = [rs.cloud_count
-                           for rs in revised_sheets
-                           if rs.cloud_count > 0]
+cloudcount_dataset = chart.data.new_dataset("Revision Cloud Count")
+cloudcount_dataset.set_color("black")
+cloudcount_dataset.data = [
+    rs.cloud_count for rs in revised_sheets if rs.cloud_count > 0
+]
 
 chart.draw()
 
@@ -228,32 +234,38 @@ chart.draw()
 for rev_sheet in revised_sheets:
     if rev_sheet.rev_count > 0:
         console.print_md(
-            '** Sheet {}: {}**\n\n'
-            'Revision Count: {}\n\n'
-            'Revision Cloud Count: {}\n\n'
-            'Revision Numbers: {}'
-            .format(rev_sheet.sheet_number,
-                    rev_sheet.sheet_name,
-                    rev_sheet.rev_count,
-                    rev_sheet.cloud_count,
-                    coreutils.join_strings(rev_sheet.get_revision_numbers(),
-                                           separator=',')))
+            "** Sheet {}: {}**\n\n"
+            "Revision Count: {}\n\n"
+            "Revision Cloud Count: {}\n\n"
+            "Revision Numbers: {}".format(
+                rev_sheet.sheet_number,
+                rev_sheet.sheet_name,
+                rev_sheet.rev_count,
+                rev_sheet.cloud_count,
+                coreutils.join_strings(rev_sheet.get_revision_numbers(), separator=","),
+            )
+        )
 
         if rev_sheet.additional_revisions_count > 0:
             console.print_md(
-                'Additional Revisions Count: {} (revisions not associated with a cloud on this sheet)'
-                .format(rev_sheet.additional_revisions_count)
+                "Additional Revisions Count: {} (revisions not associated with a cloud on this sheet)".format(
+                    rev_sheet.additional_revisions_count
+                )
             )
 
         comments = rev_sheet.get_comments()
         if comments:
-            print('\t\tRevision comments:\n{}'
-                  .format('\n'.join(['\t\t{}'.format(cmt)
-                                     for cmt in comments])))
+            print(
+                "\t\tRevision comments:\n{}".format(
+                    "\n".join(["\t\t{}".format(cmt) for cmt in comments])
+                )
+            )
 
         marks = rev_sheet.get_all_revision_marks()
         if marks:
-            print('\n\t\tRevision Marks:\n{}'
-                  .format('\n'.join(['\t\t{}'.format(mrk)
-                                     for mrk in marks])))
+            print(
+                "\n\t\tRevision Marks:\n{}".format(
+                    "\n".join(["\t\t{}".format(mrk) for mrk in marks])
+                )
+            )
         console.insert_divider()

--- a/pyrevitlib/pyrevit/revit/report.py
+++ b/pyrevitlib/pyrevit/revit/report.py
@@ -1,9 +1,12 @@
 """"Utility methods for reporting Revit data uniformly."""
 
-from pyrevit import DB
+from pyrevit import DB, HOST_APP
 from pyrevit.output import PyRevitOutputWindow
 from pyrevit.revit import query
 
+app = HOST_APP.app
+doc = HOST_APP.doc
+revit_version = int(app.VersionNumber)
 
 def print_revision(rev, prefix='', print_id=True):
     """Print a revision.
@@ -13,11 +16,20 @@ def print_revision(rev, prefix='', print_id=True):
         prefix (str, optional): prefix to add to the output text. Defaults to empty string.
         print_id (bool, optional): whether to print the revision id. Defaults to True.
     """
+    try:
+        if revit_version > 2022:
+            revision_sequence = doc.GetElement(rev.RevisionNumberingSequenceId)
+            revision_number_type = revision_sequence.NumberType
+        else:
+            revision_number_type = rev.NumberType
+    except:
+        revision_number_type = ""
+
     outstr = 'SEQ#: {} REV#: {} DATE: {} TYPE: {} DESC: {} ' \
              .format(rev.SequenceNumber,
                      str(query.get_param(rev, 'RevisionNumber', '')).ljust(5),
                      str(rev.RevisionDate).ljust(10),
-                     str(rev.NumberType if rev.NumberType else "").ljust(15),
+                     str(revision_number_type).ljust(15),
                      str(rev.Description).replace('\n', '').replace('\r', ''))
     if print_id:
         outstr = PyRevitOutputWindow.linkify(rev.Id) + '\t' + outstr

--- a/pyrevitlib/pyrevit/revit/report.py
+++ b/pyrevitlib/pyrevit/revit/report.py
@@ -27,7 +27,7 @@ def print_revision(rev, prefix='', print_id=True):
 
     outstr = 'SEQ#: {} REV#: {} DATE: {} TYPE: {} DESC: {} ' \
              .format(rev.SequenceNumber,
-                     str(query.get_param(rev, 'RevisionNumber', '')).ljust(5),
+                     str(rev.RevisionNumber).ljust(5),
                      str(rev.RevisionDate).ljust(10),
                      str(revision_number_type).ljust(15),
                      str(rev.Description).replace('\n', '').replace('\r', ''))


### PR DESCRIPTION
## Description

Fixes a changed API method **in** +2023 versions --> "revision.**NumberType**" that was moved to the RevisionNumberingSequenceId class.
Fixes #2004 Bug. Revisions of dependent views weren't listed by the "Generate Revision Report". Found a workaround for that.
Adds accuracy and consistency to revision and cloud counts.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:
- [x] Code follows the PEP 8 style guide.
- [x] Code has been formatted with Black.
- [x] Changes are tested and verified to work as expected.

---

## Related Issues
- Resolves #2004 

---

## Additional Notes

Black "messed up" the formatting, so the diffs are huge! The penultimate commit shows what has really changed.
@jmcouffin, can we discuss the best practices for that?