### PR TITLE
Enhance get_view_filters function to support ordered retrieval of filters

### DIFF
--- a/pyrevitlib/pyrevit/revit/db/query.py
+++ b/pyrevitlib/pyrevit/revit/db/query.py
@@ -3121,20 +3121,28 @@ def is_cropable_view(view):
     )
 
 
-def get_view_filters(view):
+def get_view_filters(view, ordered=True):
     """
     Retrieves the filters applied to a given Revit view.
 
     Args:
         view (Autodesk.Revit.DB.View): The Revit view from which to retrieve the filters.
+        ordered (bool, optional): If True, returns filters in their proper order using GetOrderedFilters().
+                                 If False, returns filters in arbitrary order using GetFilters().
+                                 Defaults to True.
 
     Returns:
         list[Autodesk.Revit.DB.Element]: A list of filter elements applied to the view.
     """
     view_filters = []
-    for filter_id in view.GetFilters():
-        filter_element = view.Document.GetElement(filter_id)
-        view_filters.append(filter_element)
+    if ordered:
+        for filter_id in view.GetOrderedFilters():
+            filter_element = view.Document.GetElement(filter_id)
+            view_filters.append(filter_element)
+    else:
+        for filter_id in view.GetFilters():
+            filter_element = view.Document.GetElement(filter_id)
+            view_filters.append(filter_element)
     return view_filters
 
 


### PR DESCRIPTION
## Description

Enhance get_view_filters function to support ordered retrieval of filters. Added optional parameter to return filters in their proper order or arbitrary order.
The decision was made to retain the ordered list while querying filters, as there are no specific use cases where the unordered list would be required in actual tools.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2316

---

## Additional Notes

thanks @Wurschdhaud for the tip


