### PR TITLE
Remove logger from report.py

### DIFF
--- a/pyrevitlib/pyrevit/revit/report.py
+++ b/pyrevitlib/pyrevit/revit/report.py
@@ -8,8 +8,6 @@ app = HOST_APP.app
 doc = HOST_APP.doc
 revit_version = int(app.VersionNumber)
 
-logger = script.get_logger()
-
 
 def print_revision(rev, prefix='', print_id=True):
     """Print a revision.
@@ -19,15 +17,12 @@ def print_revision(rev, prefix='', print_id=True):
         prefix (str, optional): prefix to add to the output text. Defaults to empty string.
         print_id (bool, optional): whether to print the revision id. Defaults to True.
     """
-    try:
-        if revit_version > 2022:
-            revision_sequence = doc.GetElement(rev.RevisionNumberingSequenceId)
-            revision_number_type = revision_sequence.NumberType
-        else:
-            revision_number_type = rev.NumberType
-    except Exception as e:
-        revision_number_type = ""
-        logger.warning('Could not get revision number type for revision {}: {}'.format(rev.Id, e))
+ 
+    if revit_version > 2022:
+        revision_sequence = doc.GetElement(rev.RevisionNumberingSequenceId)
+        revision_number_type = revision_sequence.NumberType
+    else:
+        revision_number_type = rev.NumberType
 
     outstr = 'SEQ#: {} REV#: {} DATE: {} TYPE: {} DESC: {} ' \
              .format(rev.SequenceNumber,


### PR DESCRIPTION
This resolves the issues of extension tools calling script.get_logger()

I would recommend calling the report within the tool level not from a library file.


# Remove logger from report.py 

## Description

Removed Logger function calling within report.py
---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [ ] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉


