### PR TITLE
Allow for an option to close other outputs for all scripts in pyrevit settings

### DIFF
--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.en_us.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.en_us.xaml
@@ -63,6 +63,16 @@
         This helps to reduce the number of open output windows.
     </system:String>
 
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Current">Current command consoles</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Current.Description">
+        Close all console windows associated with the current running command.
+    </system:String>
+
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned">All consoles</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned.Description">
+        Close all currently open console windows, even those that are not associated with the running command.
+    </system:String>
+
     <system:String x:Key="CoreSettings.Caching">Caching</system:String>
     <system:String x:Key="CoreSettings.Caching.Button">Reset Caching to default</system:String>
     <system:Double x:Key="CoreSettings.Caching.Button.With">200</system:Double>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.en_us.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.en_us.xaml
@@ -68,8 +68,8 @@
         Close all console windows associated with the current running command.
     </system:String>
 
-    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned">All consoles</system:String>
-    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned.Description">
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.CloseAll">All consoles</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.CloseAll.Description">
         Close all currently open console windows, even those that are not associated with the running command.
     </system:String>
 

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.en_us.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.en_us.xaml
@@ -60,7 +60,8 @@
     <system:String x:Key="CoreSettings.CloseOtherConsoles">Close other open consoles</system:String>
     <system:String x:Key="CoreSettings.CloseOtherConsoles.Description">
         If enabled, pyRevit will close other output consoles when a new script is run.
-        This helps to reduce the number of open output windows.
+        This helps to reduce the number of open output windows. Activate this option, unless you want to compare
+        multiple output data.
     </system:String>
 
     <system:String x:Key="CoreSettings.CloseOtherConsoles.Current">Current command consoles</system:String>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.en_us.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.en_us.xaml
@@ -57,6 +57,12 @@
     <system:String x:Key="CoreSettings.Development.Description">Misc options for pyRevit development</system:String>
     <system:String x:Key="CoreSettings.Development.LoadBeta">Load Beta Tools (Scripts with __beta__ = True, Reload is required)</system:String>
 
+    <system:String x:Key="CoreSettings.CloseOtherConsoles">Close other open consoles</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Description">
+        If enabled, pyRevit will close other output consoles when a new script is run.
+        This helps to reduce the number of open output windows.
+    </system:String>
+
     <system:String x:Key="CoreSettings.Caching">Caching</system:String>
     <system:String x:Key="CoreSettings.Caching.Button">Reset Caching to default</system:String>
     <system:Double x:Key="CoreSettings.Caching.Button.With">200</system:Double>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.fr_fr.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.fr_fr.xaml
@@ -60,7 +60,8 @@
     <system:String x:Key="CoreSettings.CloseOtherConsoles">Fermer les consoles ouvertes</system:String>
     <system:String x:Key="CoreSettings.CloseOtherConsoles.Description">
         Si activé, pyRevit fermera les autres consoles de sortie lors de l'exécution d'un nouveau script.
-        Cela permet de réduire le nombre de fenêtres de sortie ouvertes.
+        Cela permet de réduire le nombre de fenêtres de sortie ouvertes. Activez cette option, sauf si vous
+        voulez comparez les sorties de plusieurs scripts.
     </system:String>
 
     <system:String x:Key="CoreSettings.CloseOtherConsoles.Current">Consoles de la commande actuelle</system:String>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.fr_fr.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.fr_fr.xaml
@@ -57,6 +57,12 @@
     <system:String x:Key="CoreSettings.Development.Description">Options diverses pour le développement de pyRevit</system:String>
     <system:String x:Key="CoreSettings.Development.LoadBeta">Charger les outils bêta (Scripts avec __beta__ = True, le rechargement est requis)</system:String>
 
+    <system:String x:Key="CoreSettings.CloseOtherConsoles">Fermer les consoles ouvertes</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Description">
+        Si activé, pyRevit fermera les autres consoles de sortie lorsqu'un nouveau script est exécuté.
+        Cela aide à réduire le nombre de fenêtres de sortie ouvertes simultanément.
+    </system:String>
+
     <system:String x:Key="CoreSettings.Caching">Mise en cache</system:String>
     <system:String x:Key="CoreSettings.Caching.Button">Reset la mise en cache par défaut</system:String>
     <system:Double x:Key="CoreSettings.Caching.Button.With">200</system:Double>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.fr_fr.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.fr_fr.xaml
@@ -59,8 +59,18 @@
 
     <system:String x:Key="CoreSettings.CloseOtherConsoles">Fermer les consoles ouvertes</system:String>
     <system:String x:Key="CoreSettings.CloseOtherConsoles.Description">
-        Si activé, pyRevit fermera les autres consoles de sortie lorsqu'un nouveau script est exécuté.
-        Cela aide à réduire le nombre de fenêtres de sortie ouvertes simultanément.
+        Si activé, pyRevit fermera les autres consoles de sortie lors de l'exécution d'un nouveau script.
+        Cela permet de réduire le nombre de fenêtres de sortie ouvertes.
+    </system:String>
+
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Current">Consoles de la commande actuelle</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Current.Description">
+        Fermer toutes les fenêtres de console associées à la commande en cours d'exécution.
+    </system:String>
+
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned">Toutes les consoles</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned.Description">
+        Fermer toutes les fenêtres de console actuellement ouvertes, même celles qui ne sont pas associées à la commande en cours.
     </system:String>
 
     <system:String x:Key="CoreSettings.Caching">Mise en cache</system:String>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.fr_fr.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.fr_fr.xaml
@@ -68,8 +68,8 @@
         Fermer toutes les fenêtres de console associées à la commande en cours d'exécution.
     </system:String>
 
-    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned">Toutes les consoles</system:String>
-    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned.Description">
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.CloseAll">Toutes les consoles</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.CloseAll.Description">
         Fermer toutes les fenêtres de console actuellement ouvertes, même celles qui ne sont pas associées à la commande en cours.
     </system:String>
 

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.ru.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.ru.xaml
@@ -69,8 +69,8 @@
         Закрыть все окна консоли, связанные с текущей выполняемой командой.
     </system:String>
 
-    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned">Все консоли</system:String>
-    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned.Description">
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.CloseAll">Все консоли</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.CloseAll.Description">
         Закрыть все открытые в данный момент окна консоли, даже те, которые не связаны с выполняемой командой.
     </system:String>
 

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.ru.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.ru.xaml
@@ -61,7 +61,17 @@
     <system:String x:Key="CoreSettings.CloseOtherConsoles">Закрывать другие открытые консоли</system:String>
     <system:String x:Key="CoreSettings.CloseOtherConsoles.Description">
         Если включено, pyRevit будет закрывать другие консоли вывода при запуске нового скрипта.
-        Это помогает уменьшить количество одновременно открытых окон вывода.
+        Это помогает уменьшить количество открытых окон вывода.
+    </system:String>
+
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Current">Консоли текущей команды</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Current.Description">
+        Закрыть все окна консоли, связанные с текущей выполняемой командой.
+    </system:String>
+
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned">Все консоли</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Orphaned.Description">
+        Закрыть все открытые в данный момент окна консоли, даже те, которые не связаны с выполняемой командой.
     </system:String>
 
     <system:String x:Key="CoreSettings.Caching">Кеширование</system:String>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.ru.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.ru.xaml
@@ -58,6 +58,12 @@
     <system:String x:Key="CoreSettings.Development.Description">Разные настройки разработки pyRevit</system:String>
     <system:String x:Key="CoreSettings.Development.LoadBeta">Загружать бета-инструменты (Скрипты с __beta__ = True, требуется перезапуск)</system:String>
 
+    <system:String x:Key="CoreSettings.CloseOtherConsoles">Закрывать другие открытые консоли</system:String>
+    <system:String x:Key="CoreSettings.CloseOtherConsoles.Description">
+        Если включено, pyRevit будет закрывать другие консоли вывода при запуске нового скрипта.
+        Это помогает уменьшить количество одновременно открытых окон вывода.
+    </system:String>
+
     <system:String x:Key="CoreSettings.Caching">Кеширование</system:String>
     <system:String x:Key="CoreSettings.Caching.Button">Сбросить настройки кеширования</system:String>
     <system:Double x:Key="CoreSettings.Caching.Button.With">220</system:Double>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.ru.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.ResourceDictionary.ru.xaml
@@ -61,7 +61,8 @@
     <system:String x:Key="CoreSettings.CloseOtherConsoles">Закрывать другие открытые консоли</system:String>
     <system:String x:Key="CoreSettings.CloseOtherConsoles.Description">
         Если включено, pyRevit будет закрывать другие консоли вывода при запуске нового скрипта.
-        Это помогает уменьшить количество открытых окон вывода.
+        Это помогает уменьшить количество открытых окон вывода. Активируйте эту опцию, если вам
+        не требуется сравнивать данные из нескольких окон вывода.
     </system:String>
 
     <system:String x:Key="CoreSettings.CloseOtherConsoles.Current">Консоли текущей команды</system:String>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
@@ -207,8 +207,8 @@
                                 </WrapPanel>
 
                                 <StackPanel Margin="10,5,10,10">
-                                    <TextBlock Margin="0,5,0,0" FontWeight="Medium" Text="{DynamicResource CoreSettings.CloseOtherConsoles}"/>
-                                    <TextBlock Margin="0,5,0,0" TextWrapping="WrapWithOverflow" Text="{DynamicResource CoreSettings.CloseOtherConsoles.Description}"/>
+                                    <TextBlock FontWeight="Medium" Margin="0,5,0,0" Text="{DynamicResource CoreSettings.CloseOtherConsoles}"/>
+                                    <TextBlock TextWrapping="WrapWithOverflow" Margin="0,5,0,0" Text="{DynamicResource CoreSettings.CloseOtherConsoles.Description}"/>
                                     <WrapPanel Margin="0,15,0,0">
                                         <ToggleButton Style="{StaticResource AnimatedSwitch}" Height="24" x:Name="minimize_consoles_cb" IsChecked="False"/>
                                         <TextBlock Margin="30,4,0,0" Text="Minimize the number of open consoles:" />
@@ -216,12 +216,11 @@
                                 </StackPanel>
 
                                 <StackPanel Margin="26,0,0,10" IsEnabled="{Binding ElementName=minimize_consoles_cb, Path=IsChecked}">
-                                    <RadioButton x:Name="closewindows_current_rb" GroupName="console_close_mode" Margin="0,5,0,5" IsChecked="True">
-                                        <TextBlock Text="Close console windows for current command" />
-                                    </RadioButton>
-                                    <RadioButton x:Name="closewindows_orphaned_rb" GroupName="console_close_mode" Margin="0,0,0,5" IsChecked="False">
-                                        <TextBlock Text="Close all orphaned console windows" />
-                                    </RadioButton>
+                                    <RadioButton x:Name="closewindows_current_rb" GroupName="console_close_mode" Margin="0,5,0,5" IsChecked="False" Content="{DynamicResource CoreSettings.CloseOtherConsoles.Current}"/>
+                                    <TextBlock TextWrapping="WrapWithOverflow" Margin="20,0,0,5" Text="{DynamicResource CoreSettings.CloseOtherConsoles.Current.Description}"/>
+
+                                    <RadioButton x:Name="closewindows_orphaned_rb" GroupName="console_close_mode" Margin="0,10,0,5" IsChecked="False" Content="{DynamicResource CoreSettings.CloseOtherConsoles.Orphaned}"/>
+                                    <TextBlock TextWrapping="WrapWithOverflow" Margin="20,0,0,0" Text="{DynamicResource CoreSettings.CloseOtherConsoles.Orphaned.Description}"/>
                                 </StackPanel>
                             </StackPanel>
                         </GroupBox>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
@@ -205,6 +205,24 @@
                                     <ToggleButton Style="{StaticResource AnimatedSwitch}" Height="24" x:Name="loadbetatools_cb" IsChecked="False"/>
                                     <TextBlock Margin="30,4,0,0" Text="{DynamicResource CoreSettings.Development.LoadBeta}"/>
                                 </WrapPanel>
+
+                                <StackPanel Margin="10,5,10,10">
+                                    <TextBlock Margin="0,5,0,0" FontWeight="Medium" Text="{DynamicResource CoreSettings.CloseOtherConsoles}"/>
+                                    <TextBlock Margin="0,5,0,0" TextWrapping="WrapWithOverflow" Text="{DynamicResource CoreSettings.CloseOtherConsoles.Description}"/>
+                                    <WrapPanel Margin="0,15,0,0">
+                                        <ToggleButton Style="{StaticResource AnimatedSwitch}" Height="24" x:Name="minimize_consoles_cb" IsChecked="False"/>
+                                        <TextBlock Margin="30,4,0,0" Text="Minimize the number of open consoles:" />
+                                    </WrapPanel>
+                                </StackPanel>
+
+                                <StackPanel Margin="26,0,0,10" IsEnabled="{Binding ElementName=minimize_consoles_cb, Path=IsChecked}">
+                                    <RadioButton x:Name="closewindows_current_rb" GroupName="console_close_mode" Margin="0,5,0,5" IsChecked="True">
+                                        <TextBlock Text="Close console windows for current command" />
+                                    </RadioButton>
+                                    <RadioButton x:Name="closewindows_orphaned_rb" GroupName="console_close_mode" Margin="0,0,0,5" IsChecked="False">
+                                        <TextBlock Text="Close all orphaned console windows" />
+                                    </RadioButton>
+                                </StackPanel>
                             </StackPanel>
                         </GroupBox>
                         <GroupBox Header="{DynamicResource CoreSettings.Caching}" Margin="0,10,0,0">

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/SettingsWindow.xaml
@@ -219,8 +219,8 @@
                                     <RadioButton x:Name="closewindows_current_rb" GroupName="console_close_mode" Margin="0,5,0,5" IsChecked="False" Content="{DynamicResource CoreSettings.CloseOtherConsoles.Current}"/>
                                     <TextBlock TextWrapping="WrapWithOverflow" Margin="20,0,0,5" Text="{DynamicResource CoreSettings.CloseOtherConsoles.Current.Description}"/>
 
-                                    <RadioButton x:Name="closewindows_orphaned_rb" GroupName="console_close_mode" Margin="0,10,0,5" IsChecked="False" Content="{DynamicResource CoreSettings.CloseOtherConsoles.Orphaned}"/>
-                                    <TextBlock TextWrapping="WrapWithOverflow" Margin="20,0,0,0" Text="{DynamicResource CoreSettings.CloseOtherConsoles.Orphaned.Description}"/>
+                                    <RadioButton x:Name="closewindows_close_all_rb" GroupName="console_close_mode" Margin="0,10,0,5" IsChecked="False" Content="{DynamicResource CoreSettings.CloseOtherConsoles.CloseAll}"/>
+                                    <TextBlock TextWrapping="WrapWithOverflow" Margin="20,0,0,0" Text="{DynamicResource CoreSettings.CloseOtherConsoles.CloseAll.Description}"/>
                                 </StackPanel>
                             </StackPanel>
                         </GroupBox>

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/bundle.yaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/bundle.yaml
@@ -38,3 +38,5 @@ tooltip:
 
     Zeigt die Konfigurationsdatei im Explorer an. 
 context: zero-doc
+engine:
+  clean: true

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
@@ -158,12 +158,13 @@ class SettingsWindow(forms.WPFWindow):
         self.loadbetatools_cb.IsChecked = user_config.load_beta
 
         self.minimize_consoles_cb.IsChecked = user_config.output_close_others
+
         if user_config.output_close_mode == 'current_command':
             self.closewindows_current_rb.IsChecked = True
-            self.closewindows_orphaned_rb.IsChecked = False
-        else:  # 'orphaned'
+            self.closewindows_close_all_rb.IsChecked = False
+        else: # 'close_all'
             self.closewindows_current_rb.IsChecked = False
-            self.closewindows_orphaned_rb.IsChecked = True
+            self.closewindows_close_all_rb.IsChecked = True
 
     def _setup_engines(self):
         """Sets up the list of available engines."""
@@ -858,7 +859,7 @@ class SettingsWindow(forms.WPFWindow):
         if self.closewindows_current_rb.IsChecked:
             user_config.output_close_mode = 'current_command'
         else:
-            user_config.output_close_mode = 'orphaned'
+            user_config.output_close_mode = 'close_all'
 
     def _save_engines(self):
         # set active cpython engine

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
@@ -156,6 +156,7 @@ class SettingsWindow(forms.WPFWindow):
         self.minhostdrivefreespace_tb.Text = str(user_config.min_host_drivefreespace)
 
         self.loadbetatools_cb.IsChecked = user_config.load_beta
+
         self.minimize_consoles_cb.IsChecked = user_config.output_close_others
         if user_config.output_close_mode == 'current_command':
             self.closewindows_current_rb.IsChecked = True

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Settings.smartbutton/script.py
@@ -156,6 +156,13 @@ class SettingsWindow(forms.WPFWindow):
         self.minhostdrivefreespace_tb.Text = str(user_config.min_host_drivefreespace)
 
         self.loadbetatools_cb.IsChecked = user_config.load_beta
+        self.minimize_consoles_cb.IsChecked = user_config.output_close_others
+        if user_config.output_close_mode == 'current_command':
+            self.closewindows_current_rb.IsChecked = True
+            self.closewindows_orphaned_rb.IsChecked = False
+        else:  # 'orphaned'
+            self.closewindows_current_rb.IsChecked = False
+            self.closewindows_orphaned_rb.IsChecked = True
 
     def _setup_engines(self):
         """Sets up the list of available engines."""
@@ -845,6 +852,12 @@ class SettingsWindow(forms.WPFWindow):
             user_config.min_host_drivefreespace = 0
 
         user_config.load_beta = self.loadbetatools_cb.IsChecked
+
+        user_config.output_close_others = self.minimize_consoles_cb.IsChecked
+        if self.closewindows_current_rb.IsChecked:
+            user_config.output_close_mode = 'current_command'
+        else:
+            user_config.output_close_mode = 'orphaned'
 
     def _save_engines(self):
         # set active cpython engine

--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -154,22 +154,7 @@ def get_output():
     Returns:
         (pyrevit.output.PyRevitOutputWindow): Output wrapper object
     """
-    from pyrevit.userconfig import user_config
-
-    # Get the output window using the output module's get_output() function
-    output_window = output.get_output()
-
-    # Apply user configuration for output window management
-    if user_config.output_close_others:
-        try:
-            if user_config.output_close_mode == 'current_command':
-                output_window.close_others()
-            else:
-                output_window.close_others(True)
-        except:
-            pass  # Silently fail if not supported
-
-    return output_window
+    return output.get_output()
 
 
 def get_config(section=None):

--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -154,7 +154,22 @@ def get_output():
     Returns:
         (pyrevit.output.PyRevitOutputWindow): Output wrapper object
     """
-    return output.get_output()
+    from pyrevit.userconfig import user_config
+
+    # Get the output window using the output module's get_output() function
+    output_window = output.get_output()
+
+    # Apply user configuration for output window management
+    if user_config.output_close_others:
+        try:
+            if user_config.output_close_mode == 'current_command':
+                output_window.close_others()
+            else:
+                output_window.close_others(True)
+        except:
+            pass  # Silently fail if not supported
+
+    return output_window
 
 
 def get_config(section=None):
@@ -264,7 +279,7 @@ def get_data_file(file_id, file_ext, add_cmd_name=False):
         script.get_data_file('mydata', 'data', add_cmd_name=True)
         ```
         '/pyRevit_2018_Command Name_mydata.data'
-        
+
 
     Data files are not cleaned up at pyRevit startup.
     Script should manage cleaning up these files.
@@ -547,7 +562,7 @@ def load_ui(ui_instance, ui_file='ui.xaml', handle_esc=True, set_owner=True):
     """Load xaml file into given window instance.
 
     If window instance defines a method named `setup` it
-    will be called after loading 
+    will be called after loading
 
     Args:
         ui_instance (forms.WPFWindow): ui form instance
@@ -679,29 +694,29 @@ def store_data(slot_name, data, this_project=True):
         ```python
         from pyrevit import revit
             from pyrevit import script
-        
-        
+
+
             class CustomData(object):
                 def __init__(self, count, element_ids):
                     self._count = count
                     # serializes the Revit native objects
                     self._elmnt_ids = [revit.serialize(x) for x in element_ids]
-        
+
                 @property
                 def count(self):
                     return self._count
-        
+
                 @property
                 def element_ids(self):
                     # de-serializes the Revit native objects
                     return [x.deserialize() for x in self._elmnt_ids]
-        
-        
+
+
             mydata = CustomData(
                 count=3,
                 element_ids=[<DB.ElementId>, <DB.ElementId>, <DB.ElementId>]
             )
-        
+
             script.store_data("Selected Elements", mydata)
         ```
 
@@ -740,24 +755,24 @@ def load_data(slot_name, this_project=True):
         ```python
         from pyrevit import revit
         from pyrevit import script
-        
-        
+
+
             class CustomData(object):
                 def __init__(self, count, element_ids):
                     self._count = count
                     # serializes the Revit native objects
                     self._elmnt_ids = [revit.serialize(x) for x in element_ids]
-        
+
                 @property
                 def count(self):
                     return self._count
-        
+
                 @property
                 def element_ids(self):
                     # de-serializes the Revit native objects
                     return [x.deserialize() for x in self._elmnt_ids]
-        
-        
+
+
             mydata = script.load_data("Selected Elements")
             mydata.element_ids
         ```

--- a/pyrevitlib/pyrevit/userconfig.py
+++ b/pyrevitlib/pyrevit/userconfig.py
@@ -303,6 +303,36 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
         )
 
     @property
+    def output_close_others(self):
+        """Whether to close other output windows."""
+        return self.core.get_option(
+            'closeothers',
+            default_value=False,
+        )
+
+    @output_close_others.setter
+    def output_close_others(self, state):
+        self.core.set_option(
+            'closeothers',
+            value=state
+        )
+
+    @property
+    def output_close_mode(self):
+        """Output window closing mode: 'current_command' or 'orphaned'."""
+        return self.core.get_option(
+            'closeomode',
+            default_value='current_command',
+        )
+
+    @output_close_mode.setter
+    def output_close_mode(self, mode):
+        self.core.set_option(
+            'closeomode',
+            value=mode
+        )
+
+    @property
     def cpython_engine_version(self):
         """CPython engine version to use."""
         return self.core.get_option(

--- a/pyrevitlib/pyrevit/userconfig.py
+++ b/pyrevitlib/pyrevit/userconfig.py
@@ -50,7 +50,21 @@ from pyrevit.coreutils import appdata
 from pyrevit.coreutils import configparser
 from pyrevit.coreutils import logger
 from pyrevit.versionmgr import upgrade
+# pylint: disable=C0103,C0413,W0703
+import os
+import os.path as op
 
+from pyrevit import EXEC_PARAMS, HOME_DIR, HOST_APP
+from pyrevit import EXTENSIONS_DEFAULT_DIR, THIRDPARTY_EXTENSIONS_DEFAULT_DIR
+from pyrevit import PYREVIT_ALLUSER_APP_DIR, PYREVIT_APP_DIR
+from pyrevit import PyRevitException
+from pyrevit import coreutils
+from pyrevit.compat import winreg as wr
+from pyrevit.coreutils import appdata
+from pyrevit.coreutils import configparser
+from pyrevit.coreutils import logger
+from pyrevit.labs import PyRevit
+from pyrevit.versionmgr import upgrade
 
 DEFAULT_CSV_SEPARATOR = ','
 
@@ -306,29 +320,29 @@ class PyRevitConfig(configparser.PyRevitConfigParser):
     def output_close_others(self):
         """Whether to close other output windows."""
         return self.core.get_option(
-            'closeothers',
+            'close_other_outputs',
             default_value=False,
         )
 
     @output_close_others.setter
     def output_close_others(self, state):
         self.core.set_option(
-            'closeothers',
+            'close_other_outputs',
             value=state
         )
 
     @property
     def output_close_mode(self):
-        """Output window closing mode: 'current_command' or 'orphaned'."""
+        """Output window closing mode: 'current_command' or 'close_all'."""
         return self.core.get_option(
-            'closeomode',
+            'close_mode',
             default_value='current_command',
         )
 
     @output_close_mode.setter
     def output_close_mode(self, mode):
         self.core.set_option(
-            'closeomode',
+            'close_mode',
             value=mode
         )
 


### PR DESCRIPTION
## Description 

This PR introduces a new configuration option to automatically close Script Consoles across multiple script runs.

Users can now enable **Minimize the number of open consoles** and choose between:

- **Current command consoles** → close all console windows associated with the current running command.
- **All consoles** → close all currently open console windows, even those not associated with the running command.

I initially tried to implement this at the Python level (`script.get_output()`), but that only worked for scripts explicitly using that variable, meaning print_md, print_html, print_table, etc. were not caught. To ensure all outputs are handled, I implemented the logic in the C# ScriptConsole file (Would appreciate review on this part as I’m not a C# guy)

@jmcouffin It's the first time I push C# code, I didn't include the compiled dlls, is that right ?

Additionally, I added a clean engine run for the Settings pushbutton to avoid inconsistent option displays across Revit instances, since configs were previously cached in memory.

--- 

## Checklist 

Before submitting your pull request, ensure the following requirements are met: 
- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black]
- [x] Changes are tested and verified to work as expected.

--- 

## Related Issues 

- Resolves #2065 

It was initially requested by @gtalarico in the #211, but @eirannejad only implemented it in the backend side and not it in the Settings window