### PR TITLE
Fix for #2243

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Objects Passing Filter.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Objects Passing Filter.pushbutton/bundle.yaml
@@ -1,0 +1,22 @@
+title:
+  ru: Выделить все объекты, проходящие через фильтр
+  fr_fr: Sélectionner tous les objets correspondant au filtre
+  en_us: Select All Objects Passing Filter
+  de_de: Alle Objekte auswählen, die dem Filter entsprechen
+tooltip:
+  ru: >-
+    Выделяет все элементы, проходящие через один или несколько выбранных фильтров
+    и отображающиеся в активном виде.
+    Полезно для быстрой фильтрации объектов по заданным условиям.
+  fr_fr: >-
+    Sélectionne tous les éléments correspondant à un ou plusieurs filtres choisis,
+    visibles dans la vue active.
+    Utile pour filtrer rapidement selon des critères définis.
+  en_us: >-
+    Selects all elements that pass one or more selected filters
+    and are visible in the active view.
+    Useful for quickly filtering elements based on predefined conditions.
+  de_de: >-
+    Wählt alle Elemente aus, die einem oder mehreren ausgewählten Filtern entsprechen
+    und in der aktuellen Ansicht sichtbar sind.
+    Praktisch für eine schnelle Filterung basierend auf vordefinierten Kriterien.

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Objects Passing Filter.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Objects Passing Filter.pushbutton/script.py
@@ -5,7 +5,7 @@ doc = revit.doc
 active_view = revit.active_view
 uidoc = revit.uidoc
 
-filters = list(DB.FilteredElementCollector(doc).OfClass(DB.FilterElement))
+filters = list(DB.FilteredElementCollector(doc).OfClass(DB.ParameterFilterElement))
 
 if not filters:
     forms.alert("No Filters found", exitscript=True)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Objects Passing Filter.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Selection.panel/select.stack/Select.pulldown/Select All Objects Passing Filter.pushbutton/script.py
@@ -1,0 +1,41 @@
+from pyrevit import forms, revit, script, DB
+from pyrevit.framework import List
+
+doc = revit.doc
+active_view = revit.active_view
+uidoc = revit.uidoc
+
+filters = list(DB.FilteredElementCollector(doc).OfClass(DB.FilterElement))
+
+if not filters:
+    forms.alert("No Filters found", exitscript=True)
+
+selected_filters = forms.SelectFromList.show(
+    sorted(filters, key=lambda f: f.Name),
+    name_attr='Name',
+    multiselect=True,
+    title='Select Filter(s)'
+)
+
+if not selected_filters:
+    script.exit()
+
+element_filters = []
+for f in selected_filters:
+    ef = f.GetElementFilter()
+    if ef:
+        element_filters.append(ef)
+
+if not element_filters:
+    forms.alert("No valid ElementFilters found.", exitscript=True)
+
+combined_filter = DB.LogicalOrFilter(List[DB.ElementFilter](element_filters))
+
+collector = DB.FilteredElementCollector(doc, active_view.Id)
+filtered_elements = collector.WherePasses(combined_filter).ToElements()
+
+if not filtered_elements:
+    forms.alert("No Elements pass that Filter", exitscript=True)
+
+element_ids = [el.Id for el in filtered_elements]
+uidoc.Selection.SetElementIds(List[DB.ElementId](element_ids))


### PR DESCRIPTION
## Description

Introduces a new function selecting all elements that pass one OR more filters. Only for elements visible in current view. 
As described in the issue, you can than hide (HH) or isolate (HI) them to do edit them.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected. - Revit 2024

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2243

---

## Additional Notes

Translations done by AI.

---

Thank you for contributing to pyRevit! 🎉
