### PR TITLE
Refactor Section Box Tool to Support Configurable Toggle for Visibility or Active State

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/bundle.yaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/bundle.yaml
@@ -4,12 +4,20 @@ title:
   en_us: Section Box
   de_de: 3D-Schnittbereich
 tooltip:
-  ru: Переключает видимость границы 3D вида в текущем 3D виде.
-  fr_fr: Bascule la visibilité de la zone de coupe dans la vue 3D actuelle
-  en_us: Toggles visibility of section box in current 3D view
+  ru: >-
+    Переключает либо видимость, либо активность границы 3D-вида в текущем 3D виде —
+    в зависимости от конфигурации. При выборе режима активности, область сохраняется при отключении
+    и восстанавливается при повторном включении.
+  fr_fr: >-
+    Bascule soit la visibilité, soit l’activation de la boîte de coupe dans la vue 3D actuelle —
+    selon la configuration. En mode d’activation, la zone actuelle est enregistrée lorsqu'elle est désactivée
+    et restaurée lorsqu'elle est réactivée.
+  en_us: >-
+    Toggles either the visibility or the active state of the section box in the current 3D view —
+    depending on configuration. In active mode, the current box is saved when disabled
+    and restored when re-enabled.
   de_de: >-
-    Dieses Werkzeug überschreibt in dieser Ansicht die Sichtbarkeit
-    des 3D-Schnittbereiches. Wenn man nochmals auf das Werkzeug klickt 
-    wird die Sichtbareit invertiert. Dies funktioniert nicht, wenn die
-    Kategorie 3D-Schnittbereiche in den Sichtbarkeit/Grafiken 
-    oder über Filter ausgeschalten wurde. 
+    Dieses Werkzeug schaltet entweder die Sichtbarkeit oder den aktiven Zustand
+    des 3D-Schnittbereichs in der aktuellen 3D-Ansicht um — je nach Konfiguration.
+    Im Aktivmodus wird der aktuelle Bereich beim Deaktivieren gespeichert und beim
+    erneuten Aktivieren wiederhergestellt.

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/config.py
@@ -1,39 +1,14 @@
 from pyrevit import script, forms
 
 my_config = script.get_config()
-
-sb_visibility = my_config.get_option("sb_visibility", True)
-sb_active = my_config.get_option("sb_active", False)
-
-
-class MyOption(forms.TemplateListItem):
-    @property
-    def name(self):
-        return str(self.item)
-
+scope = my_config.get_option("scope", "Visibility")
 
 opts = [
-    MyOption("Section Box Visibility", sb_visibility),
-    MyOption("Section Box Active", sb_active),
+    "Visibility",
+    "Active State",
 ]
+result = forms.ask_for_one_item(opts, default=scope, prompt="Select Scope")
 
-results = forms.SelectFromList.show(
-    opts,
-    title="Choose what to set",
-    multiselect=True,
-    button_name="Save Selection",
-    return_all=True,
-    width=300,
-    height=300,
-)
-
-if results:
-    selected_items = {item.item: item.state for item in results}
-    sb_visibility = selected_items.get("Section Box Visibility", True)
-    sb_active = selected_items.get("Section Box Active", False)
-    if sb_visibility and sb_active:
-        forms.alert("Can't set both to enabled", exitscript=True)
-    my_config.set_option("sb_visibility", sb_visibility)
-    my_config.set_option("sb_active", sb_active)
-
+if result:
+    my_config.set_option("scope", result)
     script.save_config()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/config.py
@@ -2,7 +2,7 @@ from pyrevit import script, forms
 
 my_config = script.get_config()
 
-sb_visbility = my_config.get_option("sb_visbility", True)
+sb_visibility = my_config.get_option("sb_visibility", True)
 sb_active = my_config.get_option("sb_active", False)
 
 
@@ -13,7 +13,7 @@ class MyOption(forms.TemplateListItem):
 
 
 opts = [
-    MyOption("Section Box Visibility", sb_visbility),
+    MyOption("Section Box Visibility", sb_visibility),
     MyOption("Section Box Active", sb_active),
 ]
 
@@ -29,11 +29,11 @@ results = forms.SelectFromList.show(
 
 if results:
     selected_items = {item.item: item.state for item in results}
-    sb_visbility = selected_items.get("Section Box Visibility", True)
+    sb_visibility = selected_items.get("Section Box Visibility", True)
     sb_active = selected_items.get("Section Box Active", False)
-    if sb_visbility and sb_active:
+    if sb_visibility and sb_active:
         forms.alert("Can't set both to enabled", exitscript=True)
-    my_config.set_option("sb_visbility", sb_visbility)
+    my_config.set_option("sb_visibility", sb_visibility)
     my_config.set_option("sb_active", sb_active)
 
     script.save_config()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/config.py
@@ -1,0 +1,39 @@
+from pyrevit import script, forms
+
+my_config = script.get_config()
+
+sb_visbility = my_config.get_option("sb_visbility", True)
+sb_active = my_config.get_option("sb_active", False)
+
+
+class MyOption(forms.TemplateListItem):
+    @property
+    def name(self):
+        return str(self.item)
+
+
+opts = [
+    MyOption("Section Box Visibility", sb_visbility),
+    MyOption("Section Box Active", sb_active),
+]
+
+results = forms.SelectFromList.show(
+    opts,
+    title="Choose what to set",
+    multiselect=True,
+    button_name="Save Selection",
+    return_all=True,
+    width=300,
+    height=300,
+)
+
+if results:
+    selected_items = {item.item: item.state for item in results}
+    sb_visbility = selected_items.get("Section Box Visibility", True)
+    sb_active = selected_items.get("Section Box Active", False)
+    if sb_visbility and sb_active:
+        forms.alert("Can't set both to enabled", exitscript=True)
+    my_config.set_option("sb_visbility", sb_visbility)
+    my_config.set_option("sb_active", sb_active)
+
+    script.save_config()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
@@ -17,6 +17,9 @@ my_config = script.get_config()
 sb_visibility = my_config.get_option("sb_visibility", True)
 sb_active = my_config.get_option("sb_active", False)
 
+if not sb_active and not sb_visibility:
+    logger.error("Invalid configuration: No mode is enabled")
+
 
 def toggle_sectionbox_visibility():
     # activate the show hidden so we can collect

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
@@ -14,7 +14,7 @@ logger = script.get_logger()
 datafile = script.get_document_data_file("SectionBox", "pym")
 
 my_config = script.get_config()
-sb_visbility = my_config.get_option("sb_visbility", True)
+sb_visibility = my_config.get_option("sb_visibility", True)
 sb_active = my_config.get_option("sb_active", False)
 
 
@@ -41,7 +41,7 @@ def toggle_sectionbox_visibility():
     active_view.DisableTemporaryViewMode(DB.TemporaryViewMode.RevealHiddenElements)
 
 
-if sb_visbility:
+if sb_visibility:
     with revit.Transaction("Toggle Section Box"):
         toggle_sectionbox_visibility()
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
@@ -14,11 +14,7 @@ logger = script.get_logger()
 datafile = script.get_document_data_file("SectionBox", "pym")
 
 my_config = script.get_config()
-sb_visibility = my_config.get_option("sb_visibility", True)
-sb_active = my_config.get_option("sb_active", False)
-
-if not sb_active and not sb_visibility:
-    logger.error("Invalid configuration: No mode is enabled")
+scope = my_config.get_option("scope", "Visibility")
 
 
 def toggle_sectionbox_visibility():
@@ -44,7 +40,7 @@ def toggle_sectionbox_visibility():
     active_view.DisableTemporaryViewMode(DB.TemporaryViewMode.RevealHiddenElements)
 
 
-if sb_visibility:
+if scope == "Visibility":
     with revit.Transaction("Toggle Section Box"):
         toggle_sectionbox_visibility()
 
@@ -114,6 +110,6 @@ def toggle_sectionbox_active():
             logger.error("No saved section box found or failed to load: {}".format(e))
 
 
-if sb_active:
+if scope == "Active State":
     with revit.Transaction("Toggle Section Box Active"):
         toggle_sectionbox_active()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
@@ -1,37 +1,118 @@
 """Toggles visibility of section box in current 3D view"""
 
+import pickle
+
 from pyrevit import framework
-from pyrevit import revit,  DB
+from pyrevit import revit, DB, script
+from pyrevit.compat import get_elementid_value_func
+
+get_elementid_value = get_elementid_value_func()
+active_view = revit.active_view
+active_view_id_value = get_elementid_value(active_view.Id)
+
+logger = script.get_logger()
+datafile = script.get_document_data_file("SectionBox", "pym")
+
+my_config = script.get_config()
+sb_visbility = my_config.get_option("sb_visbility", True)
+sb_active = my_config.get_option("sb_active", False)
 
 
-@revit.carryout('Toggle Section Box')
-def toggle_sectionbox():
+def toggle_sectionbox_visibility():
     # activate the show hidden so we can collect
     # all elements (visible and hidden)
-    activeview = revit.active_view
-    activeview.EnableRevealHiddenMode()
-    view_elements = DB.FilteredElementCollector(revit.doc, activeview.Id)\
-                      .OfCategory(DB.BuiltInCategory.OST_SectionBox)\
-                      .ToElements()
+    active_view.EnableRevealHiddenMode()
+    view_elements = (
+        DB.FilteredElementCollector(revit.doc, active_view.Id)
+        .OfCategory(DB.BuiltInCategory.OST_SectionBox)
+        .ToElements()
+    )
 
     # find section boxes, and try toggling their visibility
     # usually more than one section box shows up on the list but not
     # all of them can be toggled. Whichever that can be toggled,
     # belongs to this view
-    for sec_box in [x for x in view_elements
-                    if x.CanBeHidden(activeview)]:
-            if sec_box.IsHidden(activeview):
-                activeview.UnhideElements(
-                    framework.List[DB.ElementId]([sec_box.Id])
-                    )
-            else:
-                activeview.HideElements(
-                    framework.List[DB.ElementId]([sec_box.Id])
-                    )
+    for sec_box in [x for x in view_elements if x.CanBeHidden(active_view)]:
+        if sec_box.IsHidden(active_view):
+            active_view.UnhideElements(framework.List[DB.ElementId]([sec_box.Id]))
+        else:
+            active_view.HideElements(framework.List[DB.ElementId]([sec_box.Id]))
 
-    activeview.DisableTemporaryViewMode(
-        DB.TemporaryViewMode.RevealHiddenElements
-        )
+    active_view.DisableTemporaryViewMode(DB.TemporaryViewMode.RevealHiddenElements)
 
 
-toggle_sectionbox()
+if sb_visbility:
+    with revit.Transaction("Toggle Section Box"):
+        toggle_sectionbox_visibility()
+
+
+# Has to be done because pickle doesn't support serializing complex .NET types
+def serialize_bbox(bbox):
+    return {
+        "min": (bbox.Min.X, bbox.Min.Y, bbox.Min.Z),
+        "max": (bbox.Max.X, bbox.Max.Y, bbox.Max.Z),
+        "transform": [
+            (bbox.Transform.BasisX.X, bbox.Transform.BasisX.Y, bbox.Transform.BasisX.Z),
+            (bbox.Transform.BasisY.X, bbox.Transform.BasisY.Y, bbox.Transform.BasisY.Z),
+            (bbox.Transform.BasisZ.X, bbox.Transform.BasisZ.Y, bbox.Transform.BasisZ.Z),
+            (bbox.Transform.Origin.X, bbox.Transform.Origin.Y, bbox.Transform.Origin.Z),
+        ],
+    }
+
+
+def deserialize_bbox(data):
+    bbox = DB.BoundingBoxXYZ()
+
+    # Min/Max
+    bbox.Min = DB.XYZ(*data["min"])
+    bbox.Max = DB.XYZ(*data["max"])
+
+    # Transform
+    transform = DB.Transform.Identity
+    transform.BasisX = DB.XYZ(*data["transform"][0])
+    transform.BasisY = DB.XYZ(*data["transform"][1])
+    transform.BasisZ = DB.XYZ(*data["transform"][2])
+    transform.Origin = DB.XYZ(*data["transform"][3])
+    bbox.Transform = transform
+
+    return bbox
+
+
+def toggle_sectionbox_active():
+    if not isinstance(active_view, DB.View3D):
+        logger.error("Not a 3D view. Operation canceled.")
+        return
+
+    sectionbox_active_state = active_view.IsSectionBoxActive
+
+    try:
+        f = open(datafile, "rb")
+        view_boxes = pickle.load(f)
+        f.close()
+    except Exception:
+        view_boxes = {}
+
+    if sectionbox_active_state:
+        try:
+            sectionbox = active_view.GetSectionBox()
+            if sectionbox:
+                view_boxes[active_view_id_value] = serialize_bbox(sectionbox)
+                f = open(datafile, "wb")
+                pickle.dump(view_boxes, f)
+                f.close()
+            active_view.IsSectionBoxActive = False
+        except Exception as e:
+            logger.error("Error saving section box: {}".format(e))
+    else:
+        try:
+            if active_view_id_value in view_boxes:
+                bbox_data = view_boxes[active_view_id_value]
+                restored_bbox = deserialize_bbox(bbox_data)
+                active_view.SetSectionBox(restored_bbox)
+        except Exception as e:
+            logger.error("No saved section box found or failed to load: {}".format(e))
+
+
+if sb_active:
+    with revit.Transaction("Toggle Section Box Active"):
+        toggle_sectionbox_active()

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Toggles.panel/toggles2.stack/SectionBox.pushbutton/script.py
@@ -89,9 +89,8 @@ def toggle_sectionbox_active():
     sectionbox_active_state = active_view.IsSectionBoxActive
 
     try:
-        f = open(datafile, "rb")
-        view_boxes = pickle.load(f)
-        f.close()
+        with open(datafile, "rb") as f:
+            view_boxes = pickle.load(f)
     except Exception:
         view_boxes = {}
 
@@ -100,9 +99,8 @@ def toggle_sectionbox_active():
             sectionbox = active_view.GetSectionBox()
             if sectionbox:
                 view_boxes[active_view_id_value] = serialize_bbox(sectionbox)
-                f = open(datafile, "wb")
-                pickle.dump(view_boxes, f)
-                f.close()
+                with open(datafile, "wb") as f:
+                    pickle.dump(view_boxes, f)
             active_view.IsSectionBoxActive = False
         except Exception as e:
             logger.error("Error saving section box: {}".format(e))


### PR DESCRIPTION
## Description
This PR refactors the existing Section Box toggle tool to support two distinct operational modes based on configuration:
- Visibility mode: Toggles whether the section box is visible in the current 3D view.
- Active state mode: Toggles whether the section box is active (enabled) in the current 3D view, with saved/restored bounding box geometry per view.

The tool now respects this configuration to perform either action (not both), depending on user preference.
In active mode, the section box bounding box is serialized safely using primitive data (due to .NET serialization limits in IronPython) and stored per-view for accurate restoration.

Tooltips have been updated in all supported languages (EN, DE, FR, RU) to reflect this new behavior and configuration-dependence. **→generated by AI**

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected. **→ Revit 2024**

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

- Serialization handles BoundingBoxXYZ safely by extracting min/max points and transform components, avoiding direct .NET object pickling (which fails under IronPython).
- Each 3D view has its own section box state saved independently.

---

Thank you for contributing to pyRevit! 🎉
