### PR TITLE
Small enhancement for "Create workset for link element" command

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/config.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/config.py
@@ -1,6 +1,6 @@
 from pyrevit import script, forms
 from script import main
-my_config = script.get_config()
+my_config = script.get_config("Create Workset For Linked Element")
 
 set_type_ws = my_config.get_option("set_type_ws", False)
 set_all = my_config.get_option("set_all", False)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Project.panel/ptools.stack/Links.pulldown/Create Workset For Linked Element.pushbutton/script.py
@@ -106,7 +106,10 @@ def main():
                             )
                         )
     else:
-        alert("At least one linked element must be selected.")
+        if set_all:
+            alert("No links found in the document.")
+        else:
+            alert("At least one linked element must be selected.")
 
 
 if __name__ == "__main__":

--- a/pyrevitlib/pyrevit/script.py
+++ b/pyrevitlib/pyrevit/script.py
@@ -170,7 +170,7 @@ def get_config(section=None):
     """
     from pyrevit.userconfig import user_config
     if not section:
-        script_cfg_postfix = 'config'
+        script_cfg_postfix = '_config'
         section = EXEC_PARAMS.command_name + script_cfg_postfix
 
     try:


### PR DESCRIPTION
## Description

- Define an explicit section name to avoid the generic name in the INI config.
- Display an alert message consistent with the user config.
- Add an underscore to the generic name suffix in `script.get_config()`

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) 
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

#2795 
