### PR TITLE
Fix SelectFromList retrieving behaviour

### DIFF
--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -1018,13 +1018,19 @@ class SelectFromList(TemplateUserInputWindow):
 
     def _get_all_ctx(self):
         """Get all context items across all groups"""
-        if isinstance(self._context, dict):
-            all_items = []
-            for group_items in self._context.values():
-                all_items.extend(group_items)
-            return all_items
+        ctx = self._context
+        if ctx is None:
+            return
+
+        if isinstance(ctx, dict):
+            for group_items in ctx.values():
+                for item in group_items:
+                    yield item
+        elif isinstance(ctx, (list, tuple, set)):
+            for item in ctx:
+                yield item
         else:
-            return self._context
+            yield ctx
 
     def _list_options(self, option_filter=None):
         if option_filter:
@@ -1072,7 +1078,7 @@ class SelectFromList(TemplateUserInputWindow):
     def _get_options(self):
         if self.multiselect:
             if self.return_all:
-                return [x for x in self._get_all_ctx()]
+                return list(self._get_all_ctx())
             else:
                 return self._unwrap_options(
                     [

--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -1016,6 +1016,16 @@ class SelectFromList(TemplateUserInputWindow):
         else:
             return self._context
 
+    def _get_all_ctx(self):
+        """Get all context items across all groups"""
+        if isinstance(self._context, dict):
+            all_items = []
+            for group_items in self._context.values():
+                all_items.extend(group_items)
+            return all_items
+        else:
+            return self._context
+
     def _list_options(self, option_filter=None):
         if option_filter:
             self.checkall_b.Content = "Check"
@@ -1062,12 +1072,12 @@ class SelectFromList(TemplateUserInputWindow):
     def _get_options(self):
         if self.multiselect:
             if self.return_all:
-                return [x for x in self._get_active_ctx()]
+                return [x for x in self._get_all_ctx()]
             else:
                 return self._unwrap_options(
                     [
                         x
-                        for x in self._get_active_ctx()
+                        for x in self._get_all_ctx()
                         if x.state or x in self.list_lb.SelectedItems
                     ]
                 )


### PR DESCRIPTION
## Description

Fixes multiselect bug in SelectFromList where only selections from the currently active group were returned, losing selections from other groups.
This behavior seems unintended, as there's no logical reason for selections to be lost when switching between groups.

What I've changed:
- Added _get_all_ctx() helper method to return items from all groups
- Modified _get_options() to use _get_all_ctx() instead of _get_active_ctx() in multiselect mode
- Preserves existing behavior for non-grouped contexts and single-select

No regressions detected as far as I tested

---

## Checklist

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black)
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

#2286 