### PR TITLE
Fix for #2818 ensure

### DIFF
--- a/pyrevitlib/pyrevit/revit/db/ensure.py
+++ b/pyrevitlib/pyrevit/revit/db/ensure.py
@@ -1,11 +1,13 @@
 """Idempotent operations to ensure a database object exists."""
 import os.path as op
 
+from System import Int64
+
 from pyrevit import HOST_APP, DOCS, PyRevitException
 from pyrevit import coreutils
 from pyrevit.coreutils.logger import get_logger
 from pyrevit import DB
-from pyrevit.revit import db
+from pyrevit.compat import get_elementid_from_value_func
 from pyrevit.revit.db import query
 from pyrevit.revit.db import create
 from pyrevit.revit.db import transaction    #pylint: disable=E0611
@@ -13,7 +15,7 @@ from pyrevit.revit.db import transaction    #pylint: disable=E0611
 
 #pylint: disable=W0703,C0302,C0103
 mlogger = get_logger(__name__)
-
+get_elementid_from_value = get_elementid_from_value_func()
 
 def ensure_sharedparam(sparam_name, sparam_categories, sparam_group,
                        load_param=True, allow_vary_betwen_groups=False,
@@ -75,8 +77,8 @@ def ensure_element_ids(mixed_list):
             element_id_list.append(item.Id)
         elif hasattr(item, 'Id') and isinstance(item.Id, DB.ElementId):
             element_id_list.append(item.Id)
-        elif isinstance(item, int):
-            element_id_list.append(DB.ElementId(item))
+        elif isinstance(item, (int, Int64)):
+            element_id_list.append(get_elementid_from_value(item))
 
     return element_id_list
 


### PR DESCRIPTION
## Description

Fixes missing Int64 check.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2818

---

## Additional Notes

tested in Revit 2024 via:
```python
from pyrevit.revit.db.ensure import ensure_element_ids
from pyrevit import revit

el = revit.pick_element()

el_id = el.Id
el_id_val1 = el_id.IntegerValue
el_id_val2 = el_id.Value

print(el_id_val1, type(el_id_val1))
print(el_id_val2, type(el_id_val2))

print(ensure_element_ids(el))
print(ensure_element_ids(el_id))
print(ensure_element_ids(el_id_val1))
print(ensure_element_ids(el_id_val2))
```
Output:
```
﻿(1588869, <type 'int'>)
(1588869L, <type 'Int64'>)
[<Autodesk.Revit.DB.ElementId object at 0x000000000000C3F7 [1588869]>]
[<Autodesk.Revit.DB.ElementId object at 0x000000000000C3F8 [1588869]>]
[<Autodesk.Revit.DB.ElementId object at 0x000000000000C3F9 [1588869]>]
[<Autodesk.Revit.DB.ElementId object at 0x000000000000C3FA [1588869]>]
```
---

Thank you for contributing to pyRevit! 🎉
