### PR TITLE
add unit, storagetype to select parameters dialogue

### DIFF
--- a/pyrevitlib/pyrevit/forms/ParameterItemStyle.xaml
+++ b/pyrevitlib/pyrevit/forms/ParameterItemStyle.xaml
@@ -20,6 +20,12 @@
         <Border x:Name="IsReadOnly" Background="{DynamicResource pyRevitAccentBrush}" Height="16" Margin="10,0,0,0" Padding="8,0,8,0" Visibility="Collapsed" CornerRadius="4">
             <TextBlock Text="Read-Only" Foreground="White" FontSize="10"/>
         </Border>
+        <Border x:Name="IsUnit" Background="DarkKhaki" Height="16" Margin="10,0,0,0" Padding="8,0,8,0" Visibility="Collapsed" CornerRadius="4">
+            <TextBlock Text="Unit" Foreground="White" FontSize="10"/>
+        </Border>
+        <Border x:Name="Storagetype" Background="PowderBlue" Height="16" Margin="10,0,0,0" Padding="8,0,8,0" Visibility="Visible" CornerRadius="4">
+            <TextBlock Text="{Binding storagetype}" Foreground="LightSlateGray" FontSize="10"/>
+        </Border>
     </WrapPanel>
     <ControlTemplate.Triggers>
         <DataTrigger Binding="{Binding Path=istype}" Value="True">
@@ -27,6 +33,9 @@
         </DataTrigger>
         <DataTrigger Binding="{Binding Path=isreadonly}" Value="True">
             <Setter TargetName="IsReadOnly" Property="Visibility" Value="Visible"/>
+        </DataTrigger>
+        <DataTrigger Binding="{Binding Path=isunit}" Value="True">
+            <Setter TargetName="IsUnit" Property="Visibility" Value="Visible"/>
         </DataTrigger>
     </ControlTemplate.Triggers>
 </ControlTemplate>

--- a/pyrevitlib/pyrevit/forms/__init__.py
+++ b/pyrevitlib/pyrevit/forms/__init__.py
@@ -70,7 +70,7 @@ WPF_VISIBLE = framework.Windows.Visibility.Visible
 XAML_FILES_DIR = op.dirname(__file__)
 
 
-ParamDef = namedtuple("ParamDef", ["name", "istype", "definition", "isreadonly"])
+ParamDef = namedtuple("ParamDef", ["name", "istype", "definition", "isreadonly", "isunit", "storagetype"])
 """Parameter definition tuple.
 
 Attributes:
@@ -78,6 +78,8 @@ Attributes:
     istype (bool): true if type parameter, otherwise false
     definition (Autodesk.Revit.DB.Definition): parameter definition object
     isreadonly (bool): true if the parameter value can't be edited
+    isunit (bool): true if its ForgeTypeId is measurable
+    storagetype (Autodesk.Revit.DB.Storagetype): String, Integer, Double or ElementId
 """
 
 
@@ -2735,6 +2737,12 @@ def select_parameters(
                     istype=False,
                     definition=x.Definition,
                     isreadonly=x.IsReadOnly,
+                    isunit=(
+                        DB.UnitUtils.IsMeasurableSpec(x.Definition.GetDataType())
+                        if HOST_APP.is_newer_than(2022, True)
+                        else False
+                    ),
+                    storagetype=x.StorageType,
                 )
                 for x in src_element.Parameters
                 if x.StorageType != non_storage_type
@@ -2752,6 +2760,12 @@ def select_parameters(
                         istype=True,
                         definition=x.Definition,
                         isreadonly=x.IsReadOnly,
+                        isunit=(
+                            DB.UnitUtils.IsMeasurableSpec(x.Definition.GetDataType())
+                            if HOST_APP.is_newer_than(2022, True)
+                            else False
+                        ),
+                        storagetype=x.StorageType,
                     )
                     for x in src_type.Parameters
                     if x.StorageType != non_storage_type


### PR DESCRIPTION
## Description

Enhances the parameter selection dialogue, by providing additional, not by revit UI exposed information about the parameters. For compat prior to Revit 2022, where measurable wasn't available, a check has been included.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
