### PR TITLE
Fix for orient view commands

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient Section Box To Face.pushbutton/script.py
@@ -33,7 +33,7 @@ def orientsectionbox(view):
         options = DB.Options()
         options.ComputeReferences = True
         options.IncludeNonVisibleObjects = True
-        options.DetailLevel = DB.ViewDetailLevel.Fine
+        options.DetailLevel = curview.DetailLevel
 
         geom_elem = element.get_Geometry(options)
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient View To Face.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/3D.pulldown/Orient View To Face.pushbutton/script.py
@@ -30,7 +30,7 @@ def reorient(view):
         options = DB.Options()
         options.ComputeReferences = True
         options.IncludeNonVisibleObjects = True
-        options.DetailLevel = DB.ViewDetailLevel.Fine
+        options.DetailLevel = curview.DetailLevel
 
         geom_elem = element.get_Geometry(options)
 


### PR DESCRIPTION
## Description

was using default level fine, which can lead to errors if the family has different solids depending on detail level.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #[issue number]

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
