### PR TITLE
Update ADC to enable users to aquire paths for the active model

### DIFF
--- a/pyrevitlib/pyrevit/interop/adc.py
+++ b/pyrevitlib/pyrevit/interop/adc.py
@@ -170,9 +170,9 @@ def get_model_path(path):
     """Get the Model Path of the model on ADC."""
     adc = _get_adc()
     drv_info = _get_drive_from_path(adc, path)
-    org_name = _get_organization_name(drv_info, path)
-    if org_name:
-        if drv_info:
+    if drv_info:
+        org_name = _get_organization_name(drv_info, path)
+        if org_name:
             drv_schema = ADC_DRIVE_SCHEMA.format(drive_name=drv_info.Name)
             rel_path = path.replace(drv_schema, "")
             return os.path.normpath(os.path.join(

--- a/pyrevitlib/pyrevit/interop/adc.py
+++ b/pyrevitlib/pyrevit/interop/adc.py
@@ -130,6 +130,8 @@ def _get_organization_name(drv_info, path):
     """Get the organization name from the ADC path."""
     drive_schema = ADC_DRIVE_SCHEMA.format(drive_name=drv_info.Name)
     parts = path.replace(drive_schema, "").split('/')
+    if len(parts) < 2:
+        return None
     file_name = parts[1]
     drv_local_path = op.normpath(drv_info.WorkspaceLocation)
     subdirs = os.walk(drv_local_path)

--- a/pyrevitlib/pyrevit/interop/adc.py
+++ b/pyrevitlib/pyrevit/interop/adc.py
@@ -73,9 +73,9 @@ def _get_drive_from_local_path(adc, local_path):
 def _drive_path_to_local_path(drv_info, path):
     drive_schema = ADC_DRIVE_SCHEMA.format(drive_name=drv_info.Name)
     return op.normpath(
-        op.join(drv_info.WorkspaceLocation,
-                  path.replace(drive_schema, ""))
-        )
+        op.join(drv_info.WorkspaceLocation, path.replace(drive_schema, ""))
+    )
+
 
 def _ensure_local_path(adc, path):
     drv_info = _get_drive_from_path(adc, path)
@@ -129,7 +129,7 @@ def _get_item_property_id_value(adc, drive, item, prop_id):
 def _get_organization_name(drv_info, path):
     """Get the organization name from the ADC path."""
     drive_schema = ADC_DRIVE_SCHEMA.format(drive_name=drv_info.Name)
-    parts = path.replace(drive_schema, "").split('/')
+    parts = path.replace(drive_schema, "").split("/")
     if len(parts) < 2:
         return None
     file_name = parts[1]
@@ -175,11 +175,8 @@ def get_model_path(path):
         if org_name:
             drv_schema = ADC_DRIVE_SCHEMA.format(drive_name=drv_info.Name)
             rel_path = path.replace(drv_schema, "")
-            return os.path.normpath(os.path.join(
-                drv_info.WorkspaceLocation,
-                  org_name, 
-                  rel_path
-                )
+            return os.path.normpath(
+                os.path.join(drv_info.WorkspaceLocation, org_name, rel_path)
             )
     return None
 


### PR DESCRIPTION
Added 2 functions to:
1- Get the organization name (ACC Hub).
2- Build a local path for the active model.


## Description

The ADC library enables users to acquire local paths for files linked to the model, but not the active doc itself, this PR will attempt at solving it.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.