### PR TITLE
Change ElementId(-1) to ElementId.InvalidElementId

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Views.pulldown/Find Views By Filter.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Views.pulldown/Find Views By Filter.pushbutton/script.py
@@ -14,10 +14,9 @@ views = DB.FilteredElementCollector(revit.doc)\
           .WhereElementIsNotElementType()\
           .ToElements()
 
-ELEMENT_ID_NULL = DB.ElementId(-1)
 
 def elementid_has_value(p):
-    return p.AsElementId() != ELEMENT_ID_NULL
+    return p.AsElementId() != DB.ElementId.InvalidElementId
 
 
 def find_views_with_underlay(invert=False):

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Views.pulldown/Remove Underlay From Selected Views.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Views.pulldown/Remove Underlay From Selected Views.pushbutton/script.py
@@ -21,7 +21,7 @@ if selected_views:
                     int(DB.BuiltInCategory.OST_Views) \
                     and (view.CanBePrinted):
                 if HOST_APP.is_newer_than(2016):
-                    view.SetUnderlayRange(DB.ElementId(-1), DB.ElementId(-1))
+                    view.SetUnderlayRange(DB.ElementId.InvalidElementId, DB.ElementId.InvalidElementId)
                 else:
                     p = view.get_Parameter(
                         DB.BuiltInParameter.VIEW_UNDERLAY_ID


### PR DESCRIPTION
## Description

Due to API changes constructor with int isnt available anymore. Changing to InvalidElementId makes it version neutral.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command: **no reformatting of old code**
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves Status: #2851

---

## Additional Notes

Include any additional context, screenshots, or considerations for reviewers.

---

Thank you for contributing to pyRevit! 🎉
