### PR TITLE
fix(newloader): honor authusers from extensions.json for C# UI loading

### DIFF
--- a/dev/pyRevitLoader/pyRevitExtensionParser/ExtensionParser.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParser/ExtensionParser.cs
@@ -244,6 +244,27 @@ namespace pyRevitExtensionParser
             _pythonScriptCache.Clear();
             _readScriptMetadataCache = null;
             BundleParser.BundleYamlParser.ClearCache();
+            ExtensionRegistryAuth.ClearCache();
+        }
+
+        internal static List<string> GetExtensionRootsForAuthLookup()
+        {
+            return GetCachedExtensionRoots();
+        }
+
+        internal static List<string> GetExtensionLookupSources()
+        {
+            return GetConfig().ExtensionLookupSources ?? new List<string>();
+        }
+
+        internal static bool FileExistsForAuthLookup(string path)
+        {
+            return FileExists(path);
+        }
+
+        internal static void LogParseExceptionForAuthLookup(string parsedFile, Exception ex)
+        {
+            LogParseException(parsedFile, ex);
         }
 
         /// <summary>
@@ -510,6 +531,7 @@ namespace pyRevitExtensionParser
             bool rocketModeCompatible = false;
             List<string> authUsers = null;
             List<string> authGroups = null;
+            string manifestName = null;
             var extensionJsonPath = Path.Combine(extDir, "extension.json");
             if (FileExists(extensionJsonPath))
             {
@@ -517,6 +539,8 @@ namespace pyRevitExtensionParser
                 {
                     var jsonContent = File.ReadAllText(extensionJsonPath);
                     var json = JObject.Parse(jsonContent);
+
+                    manifestName = json["name"]?.ToString();
 
                     // Read templates section if present
                     var templates = json["templates"] as JObject;
@@ -581,6 +605,13 @@ namespace pyRevitExtensionParser
                     LogParseException(extensionJsonPath, ex);
                 }
             }
+
+            ExtensionRegistryAuth.ApplyRegistryAuthorization(
+                extDir,
+                extName,
+                manifestName,
+                ref authUsers,
+                ref authGroups);
 
             // pyRevitCore is always rocket mode compatible (hardcoded, matches Python behavior)
             if (string.Equals(extName, "pyRevitCore", StringComparison.OrdinalIgnoreCase))

--- a/dev/pyRevitLoader/pyRevitExtensionParser/ExtensionRegistryAuth.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParser/ExtensionRegistryAuth.cs
@@ -206,7 +206,7 @@ namespace pyRevitExtensionParser
         {
             foreach (var value in source)
             {
-                if (!target.Contains(value, StringComparer.OrdinalIgnoreCase))
+                if (!target.Exists(x => string.Equals(x, value, StringComparison.OrdinalIgnoreCase)))
                     target.Add(value);
             }
         }

--- a/dev/pyRevitLoader/pyRevitExtensionParser/ExtensionRegistryAuth.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParser/ExtensionRegistryAuth.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using pyRevitLabs.Json.Linq;
+
+namespace pyRevitExtensionParser
+{
+    /// <summary>
+    /// Reads extension authorization metadata from registry definition files
+    /// (extensions.json and configured lookup sources), matching Python exts.extpackages.
+    /// </summary>
+    internal static class ExtensionRegistryAuth
+    {
+        internal const string RegistryFileName = "extensions.json";
+
+        private static Dictionary<string, RegistryAuthEntry> _registryAuthByName;
+
+        internal sealed class RegistryAuthEntry
+        {
+            public List<string> AuthorizedUsers { get; } = new List<string>();
+            public List<string> AuthorizedGroups { get; } = new List<string>();
+        }
+
+        internal static void ClearCache()
+        {
+            _registryAuthByName = null;
+        }
+
+        internal static void ApplyRegistryAuthorization(
+            string extDir,
+            string folderName,
+            string manifestName,
+            ref List<string> authUsers,
+            ref List<string> authGroups)
+        {
+            if (string.IsNullOrWhiteSpace(extDir))
+                return;
+
+            var lookupNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(folderName))
+                lookupNames.Add(folderName);
+            if (!string.IsNullOrWhiteSpace(manifestName))
+                lookupNames.Add(manifestName);
+
+            if (lookupNames.Count == 0)
+                return;
+
+            EnsureRegistryCache(extDir);
+
+            foreach (var lookupName in lookupNames)
+            {
+                if (!_registryAuthByName.TryGetValue(lookupName, out var entry))
+                    continue;
+
+                MergeAuthList(ref authUsers, entry.AuthorizedUsers);
+                MergeAuthList(ref authGroups, entry.AuthorizedGroups);
+            }
+        }
+
+        private static void EnsureRegistryCache(string extDir)
+        {
+            if (_registryAuthByName != null)
+                return;
+
+            _registryAuthByName =
+                new Dictionary<string, RegistryAuthEntry>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var sourcePath in CollectDefinitionSourcePaths(extDir))
+            {
+                LoadRegistryAuthFromFile(sourcePath, _registryAuthByName);
+            }
+        }
+
+        internal static IEnumerable<string> CollectDefinitionSourcePaths(string extDir)
+        {
+            var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (!string.IsNullOrWhiteSpace(extDir))
+            {
+                var fullExtDir = Path.GetFullPath(extDir);
+                foreach (var root in ExtensionParser.GetExtensionRootsForAuthLookup())
+                {
+                    if (IsUnderRoot(fullExtDir, root))
+                    {
+                        paths.Add(Path.Combine(Path.GetFullPath(root), RegistryFileName));
+                    }
+                }
+
+                var parentDir = Path.GetDirectoryName(fullExtDir);
+                if (!string.IsNullOrEmpty(parentDir))
+                {
+                    paths.Add(Path.Combine(parentDir, RegistryFileName));
+                }
+            }
+            else
+            {
+                foreach (var root in ExtensionParser.GetExtensionRootsForAuthLookup())
+                {
+                    paths.Add(Path.Combine(Path.GetFullPath(root), RegistryFileName));
+                }
+            }
+
+            foreach (var source in ExtensionParser.GetExtensionLookupSources())
+            {
+                if (string.IsNullOrWhiteSpace(source))
+                    continue;
+
+                try
+                {
+                    var expanded = Environment.ExpandEnvironmentVariables(source.Trim());
+                    paths.Add(Path.GetFullPath(expanded));
+                }
+                catch
+                {
+                    // Ignore invalid configured lookup source paths.
+                }
+            }
+
+            return paths;
+        }
+
+        private static void LoadRegistryAuthFromFile(
+            string filePath,
+            Dictionary<string, RegistryAuthEntry> cache)
+        {
+            if (!ExtensionParser.FileExistsForAuthLookup(filePath))
+                return;
+
+            try
+            {
+                var jsonContent = File.ReadAllText(filePath);
+                var json = JObject.Parse(jsonContent);
+                foreach (var entry in EnumerateRegistryEntries(json))
+                {
+                    var name = entry["name"]?.ToString();
+                    if (string.IsNullOrWhiteSpace(name))
+                        continue;
+
+                    var users = ParseStringArray(entry["authusers"]);
+                    var groups = ParseStringArray(entry["authgroups"]);
+                    if (users.Count == 0 && groups.Count == 0)
+                        continue;
+
+                    if (!cache.TryGetValue(name, out var authEntry))
+                    {
+                        authEntry = new RegistryAuthEntry();
+                        cache[name] = authEntry;
+                    }
+
+                    MergeAuthList(authEntry.AuthorizedUsers, users);
+                    MergeAuthList(authEntry.AuthorizedGroups, groups);
+                }
+            }
+            catch (Exception ex)
+            {
+                ExtensionParser.LogParseExceptionForAuthLookup(filePath, ex);
+            }
+        }
+
+        private static IEnumerable<JObject> EnumerateRegistryEntries(JObject json)
+        {
+            var extensionsArray = json["extensions"] as JArray;
+            if (extensionsArray != null)
+            {
+                foreach (var item in extensionsArray)
+                {
+                    if (item is JObject entry)
+                        yield return entry;
+                }
+
+                yield break;
+            }
+
+            yield return json;
+        }
+
+        private static List<string> ParseStringArray(JToken token)
+        {
+            var values = new List<string>();
+            var array = token as JArray;
+            if (array == null)
+                return values;
+
+            foreach (var item in array)
+            {
+                var value = item?.ToString();
+                if (!string.IsNullOrWhiteSpace(value))
+                    values.Add(value);
+            }
+
+            return values;
+        }
+
+        private static void MergeAuthList(ref List<string> target, List<string> source)
+        {
+            if (source == null || source.Count == 0)
+                return;
+
+            if (target == null)
+                target = new List<string>();
+
+            MergeAuthList(target, source);
+        }
+
+        private static void MergeAuthList(List<string> target, List<string> source)
+        {
+            foreach (var value in source)
+            {
+                if (!target.Contains(value, StringComparer.OrdinalIgnoreCase))
+                    target.Add(value);
+            }
+        }
+
+        private static bool IsUnderRoot(string fullPath, string root)
+        {
+            var fullRoot = Path.GetFullPath(root);
+            if (!fullRoot.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                fullRoot += Path.DirectorySeparatorChar;
+
+            return fullPath.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/dev/pyRevitLoader/pyRevitExtensionParser/PyRevitConfig.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParser/PyRevitConfig.cs
@@ -426,6 +426,22 @@ namespace pyRevitExtensionParser
                 _ini.IniWriteValue("core", "userextensions", PythonListParser.ToPythonListString(value));
             }
         }
+
+        /// <summary>
+        /// Gets additional extension definition source files configured under [environment] sources.
+        /// Matches Python userconfig.get_ext_sources().
+        /// </summary>
+        public List<string> ExtensionLookupSources
+        {
+            get
+            {
+                return _ini.GetPythonList("environment", "sources");
+            }
+            set
+            {
+                _ini.IniWriteValue("environment", "sources", PythonListParser.ToPythonListString(value));
+            }
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="PyRevitConfig"/> class with the specified configuration file path.
         /// </summary>

--- a/dev/pyRevitLoader/pyRevitExtensionParser/pyRevitExtensionParser.csproj
+++ b/dev/pyRevitLoader/pyRevitExtensionParser/pyRevitExtensionParser.csproj
@@ -36,6 +36,7 @@
       <Compile Include="ParserLogger.cs" />
       <Compile Include="PyRevitConfig.cs" />
       <Compile Include="ExtensionParser.cs" />
+      <Compile Include="ExtensionRegistryAuth.cs" />
       <Compile Include="IniFile.cs" />
     </ItemGroup>
 

--- a/dev/pyRevitLoader/pyRevitExtensionParserTester/ExtensionAuthUsersTests.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParserTester/ExtensionAuthUsersTests.cs
@@ -1,0 +1,160 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using pyRevitAssemblyBuilder.SessionManager;
+using pyRevitExtensionParser;
+using pyRevitExtensionParserTest.TestHelpers;
+using NUnit.Framework;
+using static pyRevitExtensionParser.ExtensionParser;
+
+namespace pyRevitExtensionParserTester
+{
+    [TestFixture]
+    public class ExtensionAuthUsersTests : TempFileTestBase
+    {
+        [TearDown]
+        public void ResetParserConfig()
+        {
+            PyRevitConfig.ClearCache();
+            ClearAllCaches();
+        }
+
+        private static void UseTestPyRevitConfig(string iniContent)
+        {
+            var configPath = Path.Combine(TestTempDir, "pyRevit_config.ini");
+            File.WriteAllText(configPath, iniContent);
+            var cfg = PyRevitConfig.Load(configPath);
+            ClearAllCaches();
+            var field = typeof(PyRevitConfig).GetField(
+                "_defaultInstance",
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null);
+            field!.SetValue(null, cfg);
+        }
+
+        [Test]
+        public void ParseExtension_ReadsAuthUsersFromExtensionJson()
+        {
+            var extPath = TestExtensionBuilder.CreateMinimalExtension(TestTempDir, "AuthFromManifest");
+            File.WriteAllText(
+                Path.Combine(extPath, "extension.json"),
+                "{\"authusers\": [\"TestUser\"]}");
+
+            ClearAllCaches();
+            var extension = ParseInstalledExtensions(extPath).Single();
+
+            Assert.That(extension.AuthorizedUsers, Is.EquivalentTo(new[] { "TestUser" }));
+        }
+
+        [Test]
+        public void ParseExtension_ReadsAuthUsersFromExtensionsRegistry()
+        {
+            var extPath = TestExtensionBuilder.CreateMinimalExtension(TestTempDir, "RegistryAuthExt");
+            var registryPath = Path.Combine(TestTempDir, "extensions.json");
+            File.WriteAllText(
+                registryPath,
+                @"{
+  ""extensions"": [
+    {
+      ""name"": ""RegistryAuthExt"",
+      ""type"": ""extension"",
+      ""authusers"": [""TestUser""]
+    }
+  ]
+}");
+
+            ClearAllCaches();
+            var extension = ParseInstalledExtensions(extPath).Single();
+
+            Assert.That(extension.AuthorizedUsers, Is.EquivalentTo(new[] { "TestUser" }));
+        }
+
+        [Test]
+        public void ParseExtension_MergesAuthUsersFromManifestAndRegistry()
+        {
+            var extPath = TestExtensionBuilder.CreateMinimalExtension(TestTempDir, "MergedAuthExt");
+            File.WriteAllText(
+                Path.Combine(extPath, "extension.json"),
+                "{\"name\": \"MergedAuthExt\", \"authusers\": [\"ManifestUser\"]}");
+            File.WriteAllText(
+                Path.Combine(TestTempDir, "extensions.json"),
+                @"{
+  ""extensions"": [
+    {
+      ""name"": ""MergedAuthExt"",
+      ""type"": ""extension"",
+      ""authusers"": [""RegistryUser""]
+    }
+  ]
+}");
+
+            ClearAllCaches();
+            var extension = ParseInstalledExtensions(extPath).Single();
+
+            Assert.That(
+                extension.AuthorizedUsers,
+                Is.EquivalentTo(new[] { "ManifestUser", "RegistryUser" }));
+        }
+
+        [Test]
+        public void ParseExtension_ReadsAuthUsersFromConfiguredLookupSource()
+        {
+            var extPath = TestExtensionBuilder.CreateMinimalExtension(TestTempDir, "LookupAuthExt");
+            var lookupPath = Path.Combine(TestTempDir, "custom-registry.json");
+            File.WriteAllText(
+                lookupPath,
+                @"{
+  ""extensions"": [
+    {
+      ""name"": ""LookupAuthExt"",
+      ""type"": ""extension"",
+      ""authusers"": [""LookupUser""]
+    }
+  ]
+}");
+            UseTestPyRevitConfig(
+                "[environment]\n" +
+                "sources = [\"" + lookupPath.Replace("\\", "\\\\") + "\"]\n");
+
+            ClearAllCaches();
+            var extension = ParseInstalledExtensions(extPath).Single();
+
+            Assert.That(extension.AuthorizedUsers, Is.EquivalentTo(new[] { "LookupUser" }));
+        }
+
+        [Test]
+        public void GetInstalledUIExtensions_ExcludesExtensionsRestrictedByRegistryAuth()
+        {
+            var extPath = TestExtensionBuilder.CreateMinimalExtension(TestTempDir, "UnauthorizedRegistryExt");
+            File.WriteAllText(
+                Path.Combine(TestTempDir, "extensions.json"),
+                @"{
+  ""extensions"": [
+    {
+      ""name"": ""UnauthorizedRegistryExt"",
+      ""type"": ""extension"",
+      ""authusers"": [""SomeoneElse""]
+    }
+  ]
+}");
+
+            ClearAllCaches();
+            var parsed = ParseInstalledExtensions(extPath).Single();
+            var service = new ExtensionManagerService();
+
+            Assert.That(parsed.AuthorizedUsers, Is.EquivalentTo(new[] { "SomeoneElse" }));
+            Assert.That(InvokeIsExtensionAllowed(service, parsed), Is.False);
+        }
+
+        private static bool InvokeIsExtensionAllowed(
+            ExtensionManagerService service,
+            ParsedExtension extension)
+        {
+            var method = typeof(ExtensionManagerService).GetMethod(
+                "IsExtensionAllowed",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null);
+            return (bool)method!.Invoke(service, new object[] { extension })!;
+        }
+    }
+}

--- a/dev/pyRevitLoader/pyRevitExtensionParserTester/pyRevitExtensionParserTest.csproj
+++ b/dev/pyRevitLoader/pyRevitExtensionParserTester/pyRevitExtensionParserTest.csproj
@@ -51,6 +51,7 @@
     <Compile Include="CSharpScriptTests.cs" />
     <Compile Include="DynamoScriptTests.cs" />
     <Compile Include="ExtensionManagerServiceTests.cs" />
+    <Compile Include="ExtensionAuthUsersTests.cs" />
     <Compile Include="AssemblyBuilderServiceTests.cs" />
     <Compile Include="HookManagerTests.cs" />
     <Compile Include="SessionManagerIntegrationTests.cs" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When using the new C# loader, extensions restricted via `authusers` could still appear in the Revit ribbon while being correctly hidden in the pyRevit Extensions Manager.

The Extensions Manager (Python) reads authorization metadata from:

- per-extension `extension.json` files
- root-level `extensions.json` registry files in each extension search directory
- additional lookup sources configured under `[environment] sources`

The C# loader only applied `authusers` / `authgroups` from per-extension `extension.json` during parsing. Registry-only restrictions were ignored during UI assembly creation, so unauthorized users still received ribbon tabs/panels.

## Solution

- Add `ExtensionRegistryAuth` to load and cache authorization metadata from registry definition files.
- Merge registry `authusers` / `authgroups` into `ParsedExtension` during parsing (union with per-extension manifest values, matching Python behavior).
- Expose `[environment] sources` via `PyRevitConfig.ExtensionLookupSources`.
- Add unit tests covering manifest, registry, merged, and lookup-source authorization cases.

## Testing

Added `ExtensionAuthUsersTests` covering:

- `authusers` in `extension.json`
- `authusers` in parent `extensions.json`
- merged auth from both sources
- auth from configured lookup source
- `ExtensionManagerService` exclusion for registry-restricted extensions

## Notes for repro

- Per-extension metadata must live in `extension.json` inside the `.extension` folder.
- Registry metadata belongs in `extensions.json` at the extension search directory root (sibling to installed `.extension` folders).

Fixes the reported mismatch between Extensions Manager visibility and ribbon UI visibility when using the new C# loader.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14fabdcd-fbe0-4dc2-8c51-b7366ce70282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14fabdcd-fbe0-4dc2-8c51-b7366ce70282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

