### PR TITLE
fix(cli): allow clone registration after failed install rollback

### DIFF
--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClones.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClones.cs
@@ -46,18 +46,20 @@ namespace pyRevitLabs.PyRevit
 
             var registeredClones = GetRegisteredClones();
 
-            if (forceUpdate && registeredClones.Contains(clone))
-                registeredClones.Remove(clone);
-
-            if (!registeredClones.Contains(clone))
+            if (forceUpdate)
             {
-                registeredClones.Add(clone);
-                SaveRegisteredClones(registeredClones);
+                registeredClones.RemoveAll(
+                    registeredClone => registeredClone.Matches(cloneName) || registeredClone.Equals(clone));
             }
-            else
+            else if (registeredClones.Contains(clone))
+            {
                 throw new PyRevitException(
                     string.Format("Clone with repo path \"{0}\" already exists.", clone.ClonePath)
                     );
+            }
+
+            registeredClones.Add(clone);
+            SaveRegisteredClones(registeredClones);
         }
 
         // renames a clone in a configs
@@ -241,6 +243,9 @@ namespace pyRevitLabs.PyRevit
             // make sure destPath exists
             CommonUtils.EnsurePath(destPath);
 
+            // Drop stale registrations before cloning so a retried install can register cleanly.
+            PruneStaleCloneRegistrations();
+
             // check existing destination path
             if (CommonUtils.VerifyPath(destPath))
             {
@@ -273,7 +278,7 @@ namespace pyRevitLabs.PyRevit
                     PyRevitClone.VerifyCloneValidity(clonedPath);
                     InstallBinariesForRepoClone(clonedPath, repoSourcePath, BinArtifactInstallMode.Clone);
                     logger.Debug("Clone successful \"{0}\"", clonedPath);
-                    RegisterClone(cloneName, clonedPath);
+                    RegisterClone(cloneName, clonedPath, forceUpdate: true);
                 }
                 catch (pyRevitBinArtifactNotFoundException ex)
                 {
@@ -287,6 +292,7 @@ namespace pyRevitLabs.PyRevit
                 {
                     logger.Debug(string.Format("Exception occured after clone complete. Deleting clone \"{0}\" | {1}",
                                                clonedPath, ex.Message));
+                    UnregisterCloneAtPath(clonedPath);
                     try
                     {
                         CommonUtils.DeleteDirectory(clonedPath);
@@ -345,6 +351,9 @@ namespace pyRevitLabs.PyRevit
             }
 
             logger.Debug("Destination path determined as \"{0}\"", destPath);
+
+            // Drop stale registrations before deploying so a retried install can register cleanly.
+            PruneStaleCloneRegistrations();
 
             // process source
             // decide to download if source is a url
@@ -463,6 +472,7 @@ namespace pyRevitLabs.PyRevit
                 {
                     logger.Debug(string.Format("Exception occured after clone from image complete. " +
                                                "Deleting clone \"{0}\" | {1}", destPath, ex.Message));
+                    UnregisterCloneAtPath(destPath);
                     try
                     {
                         CommonUtils.DeleteDirectory(destPath);
@@ -506,12 +516,13 @@ namespace pyRevitLabs.PyRevit
             {
                 PyRevitClone.VerifyCloneValidity(clonePath);
                 logger.Debug("Clone successful \"{0}\"", clonePath);
-                RegisterClone(cloneName, clonePath);
+                RegisterClone(cloneName, clonePath, forceUpdate: true);
             }
             catch (Exception ex)
             {
                 logger.Debug(string.Format("Exception occured after clone complete. Deleting clone \"{0}\" | {1}",
                                            clonePath, ex.Message));
+                UnregisterCloneAtPath(clonePath);
                 try
                 {
                     CommonUtils.DeleteDirectory(clonePath);
@@ -728,6 +739,24 @@ namespace pyRevitLabs.PyRevit
                 throw new PyRevitException(
                     string.Format("Error installing CI binaries for clone \"{0}\" | {1}", clonePath, ex.Message),
                     ex);
+            }
+        }
+
+        private static void PruneStaleCloneRegistrations()
+        {
+            GetRegisteredClones();
+        }
+
+        private static void UnregisterCloneAtPath(string clonePath)
+        {
+            if (string.IsNullOrWhiteSpace(clonePath))
+                return;
+
+            var normalizedPath = clonePath.NormalizeAsPath();
+            foreach (var clone in GetRegisteredClones().ToList())
+            {
+                if (clone.ClonePath.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
+                    UnregisterClone(clone);
             }
         }
 

--- a/dev/pyRevitLoader/pyRevitExtensionParserTester/ExtensionAuthUsersTests.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParserTester/ExtensionAuthUsersTests.cs
@@ -19,7 +19,7 @@ namespace pyRevitExtensionParserTester
             ClearAllCaches();
         }
 
-        private static void UseTestPyRevitConfig(string iniContent)
+        private void UseTestPyRevitConfig(string iniContent)
         {
             var configPath = Path.Combine(TestTempDir, "pyRevit_config.ini");
             File.WriteAllText(configPath, iniContent);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes a CLI clone failure where a retried `pyrevit clone` succeeds at git clone and CI binary download, then fails at registration with:

`Clone with repo path "C:\pyRevit\main" already exists.`

The install rollback deletes the clone directory but leaves the config entry behind. On retry, the freshly created clone is valid, so `GetRegisteredClones()` keeps the stale registration and `RegisterClone` rejects the duplicate path, which triggers another rollback.

Changes:
- Prune stale clone registrations before repo/image deploy starts
- Register deployed clones with `forceUpdate: true` so redeploying to the same path updates the entry instead of failing
- Unregister the clone path during post-install rollback cleanup so failed installs do not leave orphaned config entries

---

## Checklist

- [x] Code follows the project style guide
- [ ] Changes are tested and verified to work as expected (dotnet build not available in this environment)

---

## Related Issues

- Follow-up to CI binary download clone flow reported by Tamas Dery

---

## Additional Notes

After this fix, users with a stale `main` registration from a previous failed attempt can retry `pyrevit clone main ...` without manually running `pyrevit clones forget main` first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3f4c2c8-469e-4046-8f5f-0e02b7f899fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3f4c2c8-469e-4046-8f5f-0e02b7f899fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

