### PR TITLE
Add Blendit to the extensions catalog

### DIFF
--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -317,6 +317,19 @@
             "website": "https://biminent.com",
             "image": "",
             "dependencies": []
+        },
+        {
+            "builtin": "False",
+            "type": "extension",
+            "rocket_mode_compatible": "True",
+            "name": "Blendit",
+            "description": "One-click Revit to Blender rendering. Sends the active 3D view to Blender and renders it through a curated pipeline: photoreal, clay and shadow-study modes plus NPR line/pen/sketch/cel/hatch, an interactive review session, SVG/PDF vector export, and procedural volumetric clouds. Blender runs as a separate process; the pipeline ships inside the extension. Free, MIT-licensed.",
+            "author": "lewismconte",
+            "author_profile": "https://github.com/lewismconte",
+            "url": "https://github.com/lewismconte/blendit.git",
+            "website": "https://github.com/lewismconte/blendit",
+            "image": "",
+            "dependencies": []
         }
     ]
 }

--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -328,7 +328,7 @@
             "author_profile": "https://github.com/lewismconte",
             "url": "https://github.com/lewismconte/blendit.git",
             "website": "https://github.com/lewismconte/blendit",
-            "image": "",
+            "image": "https://raw.githubusercontent.com/lewismconte/blendit/main/media/blendit_hero.png",
             "dependencies": []
         }
     ]


### PR DESCRIPTION
Adds **Blendit** to the community extensions catalog (a single entry in `extensions/extensions.json`).

Blendit is a free, MIT-licensed one-click Revit → Blender renderer: it extracts the active 3D view and renders it in Blender through a curated pipeline — photoreal, clay and shadow-study modes plus NPR line / pen / sketch / cel / hatch, an interactive review session, SVG / PDF vector export, and procedural volumetric clouds. Blender runs as a **separate process**; the render pipeline ships inside the extension (no in-process native dependencies).

- **Repo:** https://github.com/lewismconte/blendit
- **Structure:** `.tab` + `extension.json` at the repo root (catalog-compatible)
- **Rocket-mode compatible:** yes
- **Platform:** Windows (Revit + pyRevit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
