### PR TITLE
fix(cli): honor custom BIM360 CacheLocation from Revit.ini (#3488)

### DIFF
--- a/dev/pyRevitLabs/pyRevitLabs.TargetApps.Revit/RevitCaches.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.TargetApps.Revit/RevitCaches.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 using pyRevitLabs.Common;
 using pyRevitLabs.NLog;
@@ -17,9 +12,112 @@ namespace pyRevitLabs.TargetApps.Revit {
     public class RevitCaches {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
-        // bim360 cache folder 
+        // Revit 2024 is the first version to support custom cloud cache paths via Revit.ini
+        public const int CustomCacheMinVersion = 2024;
+        public const string CloudModelCacheSection = "CloudModelCache";
+        public const string CloudModelCacheKey = "CacheLocation";
+
+        // default bim360 cache folder under %LOCALAPPDATA%
+        public static string GetDefaultBIM360CacheDirectory(int revitYear) {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Autodesk",
+                "Revit",
+                $"Autodesk Revit {revitYear}",
+                "CollaborationCache");
+        }
+
+        // Revit.ini path under %APPDATA% for the given product year
+        public static string GetRevitIniPath(int revitYear) {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Autodesk",
+                "Revit",
+                $"Autodesk Revit {revitYear}",
+                "Revit.ini");
+        }
+
+        /// <summary>
+        /// Read CacheLocation from a Revit.ini file without expanding env vars.
+        /// Returns null when the section/key is missing or empty.
+        /// </summary>
+        public static string ReadCloudModelCacheLocation(string iniPath) {
+            if (!CommonUtils.VerifyFile(iniPath)) {
+                logger.Debug("Revit.ini not found: {0}", iniPath);
+                return null;
+            }
+
+            try {
+                string currentSection = null;
+                foreach (var rawLine in File.ReadLines(iniPath)) {
+                    var line = rawLine.Trim();
+                    if (line.Length == 0 || line.StartsWith(";") || line.StartsWith("#"))
+                        continue;
+
+                    if (line.StartsWith("[") && line.EndsWith("]")) {
+                        currentSection = line.Substring(1, line.Length - 2).Trim();
+                        continue;
+                    }
+
+                    if (!string.Equals(currentSection, CloudModelCacheSection, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var idx = line.IndexOf('=');
+                    if (idx < 0)
+                        continue;
+
+                    var key = line.Substring(0, idx).Trim();
+                    if (!string.Equals(key, CloudModelCacheKey, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var value = StripSurroundingQuotes(line.Substring(idx + 1).Trim());
+                    if (string.IsNullOrWhiteSpace(value)) {
+                        logger.Debug("Empty CacheLocation in Revit.ini: {0}", iniPath);
+                        return null;
+                    }
+
+                    logger.Debug("CacheLocation from Revit.ini ({0}): {1}", iniPath, value);
+                    return value;
+                }
+            }
+            catch (Exception ex) {
+                logger.Warn("Failed to read Revit.ini @ {0} | {1}", iniPath, ex.Message);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Resolve a custom BIM360/ACC cache root from Revit.ini for Revit 2024+.
+        /// Returns null so callers fall back to the default location.
+        /// </summary>
+        public static string GetCustomBIM360CacheDirectory(int revitYear, string iniPath = null) {
+            if (revitYear < CustomCacheMinVersion)
+                return null;
+
+            var pathToIni = string.IsNullOrWhiteSpace(iniPath) ? GetRevitIniPath(revitYear) : iniPath;
+            logger.Debug("Checking Revit.ini for custom cache path: {0}", pathToIni);
+
+            var raw = ReadCloudModelCacheLocation(pathToIni);
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+
+            var customPath = Path.GetFullPath(CommonUtils.ExpandEnvironmentPath(raw));
+            if (!CommonUtils.VerifyPath(customPath)) {
+                logger.Debug("Custom cache path from Revit.ini does not exist: {0}", customPath);
+                return null;
+            }
+
+            logger.Debug("Using custom cache root from Revit.ini: {0}", customPath);
+            return customPath;
+        }
+
+        // bim360 cache folder (custom CacheLocation for 2024+ when present, else default)
         public static string GetBIM360CacheDirectory(int revitYear) {
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Autodesk", "Revit", $"Autodesk Revit {revitYear.ToString()}", "CollaborationCache");
+            var custom = GetCustomBIM360CacheDirectory(revitYear);
+            if (!string.IsNullOrEmpty(custom))
+                return custom;
+            return GetDefaultBIM360CacheDirectory(revitYear);
         }
 
         // clear bim360 cache
@@ -39,9 +137,17 @@ namespace pyRevitLabs.TargetApps.Revit {
 
         // clear all bim360 caches
         public static void ClearAllCaches(RevitCacheType cacheType) {
-            var cacheDirFinder = new Regex(@"\d\d\d\d");
             foreach (RevitProduct revitProduct in RevitProduct.ListInstalledProducts())
                 ClearCache(revitProduct.ProductYear, cacheType);
+        }
+
+        private static string StripSurroundingQuotes(string value) {
+            if (value == null || value.Length < 2)
+                return value;
+            if ((value[0] == '"' && value[value.Length - 1] == '"') ||
+                (value[0] == '\'' && value[value.Length - 1] == '\''))
+                return value.Substring(1, value.Length - 2);
+            return value;
         }
     }
 }

--- a/dev/pyRevitLabs/pyRevitLabs.TargetApps.Revit/RevitCaches.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.TargetApps.Revit/RevitCaches.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 
+using MadMilkman.Ini;
+
 using pyRevitLabs.Common;
 using pyRevitLabs.NLog;
 
@@ -12,13 +14,13 @@ namespace pyRevitLabs.TargetApps.Revit {
     public class RevitCaches {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
-        // Revit 2024 is the first version to support custom cloud cache paths via Revit.ini
+        // Revit 2024 is the first version to support custom cloud cache paths
         public const int CustomCacheMinVersion = 2024;
         public const string CloudModelCacheSection = "CloudModelCache";
         public const string CloudModelCacheKey = "CacheLocation";
 
-        // default bim360 cache folder under %LOCALAPPDATA%
-        public static string GetDefaultBIM360CacheDirectory(int revitYear) {
+        // bim360 cache folder (default location)
+        public static string GetBIM360CacheDirectory(int revitYear) {
             return Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                 "Autodesk",
@@ -27,8 +29,8 @@ namespace pyRevitLabs.TargetApps.Revit {
                 "CollaborationCache");
         }
 
-        // Revit.ini path under %APPDATA% for the given product year
-        public static string GetRevitIniPath(int revitYear) {
+        // path to Revit.ini for a given revit year
+        public static string GetRevitIniFile(int revitYear) {
             return Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                 "Autodesk",
@@ -43,59 +45,57 @@ namespace pyRevitLabs.TargetApps.Revit {
         /// </summary>
         public static string ReadCloudModelCacheLocation(string iniPath) {
             if (!CommonUtils.VerifyFile(iniPath)) {
-                logger.Debug("Revit.ini not found: {0}", iniPath);
+                logger.Debug("Revit.ini not found @ {0}", iniPath);
                 return null;
             }
 
             try {
-                string currentSection = null;
-                foreach (var rawLine in File.ReadLines(iniPath)) {
-                    var line = rawLine.Trim();
-                    if (line.Length == 0 || line.StartsWith(";") || line.StartsWith("#"))
-                        continue;
+                var cfgOps = new IniOptions();
+                cfgOps.KeySpaceAroundDelimiter = true;
+                var iniFile = new IniFile(cfgOps);
 
-                    if (line.StartsWith("[") && line.EndsWith("]")) {
-                        currentSection = line.Substring(1, line.Length - 2).Trim();
-                        continue;
-                    }
-
-                    if (!string.Equals(currentSection, CloudModelCacheSection, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    var idx = line.IndexOf('=');
-                    if (idx < 0)
-                        continue;
-
-                    var key = line.Substring(0, idx).Trim();
-                    if (!string.Equals(key, CloudModelCacheKey, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    var value = StripSurroundingQuotes(line.Substring(idx + 1).Trim());
-                    if (string.IsNullOrWhiteSpace(value)) {
-                        logger.Debug("Empty CacheLocation in Revit.ini: {0}", iniPath);
-                        return null;
-                    }
-
-                    logger.Debug("CacheLocation from Revit.ini ({0}): {1}", iniPath, value);
-                    return value;
+                // Allow Revit (or another process) to keep the file open while we read.
+                using (var iniStream = File.Open(iniPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
+                    iniFile.Load(iniStream);
                 }
+
+                if (!iniFile.Sections.Contains(CloudModelCacheSection))
+                    return null;
+
+                var section = iniFile.Sections[CloudModelCacheSection];
+                if (!section.Keys.Contains(CloudModelCacheKey))
+                    return null;
+
+                var rawValue = section.Keys[CloudModelCacheKey].Value as string;
+                if (string.IsNullOrWhiteSpace(rawValue)) {
+                    logger.Debug("Empty CacheLocation in Revit.ini: {0}", iniPath);
+                    return null;
+                }
+
+                var value = StripSurroundingQuotes(rawValue.Trim());
+                if (string.IsNullOrWhiteSpace(value))
+                    return null;
+
+                logger.Debug("CacheLocation from Revit.ini ({0}): {1}", iniPath, value);
+                return value;
             }
             catch (Exception ex) {
                 logger.Warn("Failed to read Revit.ini @ {0} | {1}", iniPath, ex.Message);
+                return null;
             }
-
-            return null;
         }
 
         /// <summary>
-        /// Resolve a custom BIM360/ACC cache root from Revit.ini for Revit 2024+.
-        /// Returns null so callers fall back to the default location.
+        /// Read the custom cloud cache location from Revit.ini, if configured.
+        /// Returns null when Revit.ini is missing, the version is too old,
+        /// or the section/key is not present or empty, so callers fall back
+        /// to the default cache directory.
         /// </summary>
         public static string GetCustomBIM360CacheDirectory(int revitYear, string iniPath = null) {
             if (revitYear < CustomCacheMinVersion)
                 return null;
 
-            var pathToIni = string.IsNullOrWhiteSpace(iniPath) ? GetRevitIniPath(revitYear) : iniPath;
+            var pathToIni = string.IsNullOrWhiteSpace(iniPath) ? GetRevitIniFile(revitYear) : iniPath;
             logger.Debug("Checking Revit.ini for custom cache path: {0}", pathToIni);
 
             var raw = ReadCloudModelCacheLocation(pathToIni);
@@ -103,21 +103,20 @@ namespace pyRevitLabs.TargetApps.Revit {
                 return null;
 
             var customPath = Path.GetFullPath(CommonUtils.ExpandEnvironmentPath(raw));
-            if (!CommonUtils.VerifyPath(customPath)) {
-                logger.Debug("Custom cache path from Revit.ini does not exist: {0}", customPath);
-                return null;
-            }
-
-            logger.Debug("Using custom cache root from Revit.ini: {0}", customPath);
+            logger.Debug("custom cache root from Revit.ini: {0}", customPath);
             return customPath;
         }
 
-        // bim360 cache folder (custom CacheLocation for 2024+ when present, else default)
-        public static string GetBIM360CacheDirectory(int revitYear) {
-            var custom = GetCustomBIM360CacheDirectory(revitYear);
-            if (!string.IsNullOrEmpty(custom))
-                return custom;
-            return GetDefaultBIM360CacheDirectory(revitYear);
+        /// <summary>
+        /// Resolve the cache directory to use: custom location if configured
+        /// and it exists on disk, otherwise the default location.
+        /// </summary>
+        public static string GetActiveBIM360CacheDirectory(int revitYear, string iniPath = null) {
+            var customPath = GetCustomBIM360CacheDirectory(revitYear, iniPath);
+            if (customPath != null && CommonUtils.VerifyPath(customPath))
+                return customPath;
+
+            return GetBIM360CacheDirectory(revitYear);
         }
 
         // clear bim360 cache
@@ -125,7 +124,7 @@ namespace pyRevitLabs.TargetApps.Revit {
             // make sure all revit instances are closed
             switch (cacheType) {
                 case RevitCacheType.BIM360Cache:
-                    var cachePath = GetBIM360CacheDirectory(revitYear);
+                    var cachePath = GetActiveBIM360CacheDirectory(revitYear);
                     logger.Debug("Attempting to clean {0}", cachePath);
                     if (CommonUtils.VerifyPath(cachePath)) {
                         RevitController.KillRunningRevits(revitYear);

--- a/dev/pyRevitLabs/pyRevitLabs.TargetApps.Revit/pyRevitLabs.TargetApps.Revit.csproj
+++ b/dev/pyRevitLabs/pyRevitLabs.TargetApps.Revit/pyRevitLabs.TargetApps.Revit.csproj
@@ -14,6 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" Include="MadMilkman.Ini" Version="1.0.6" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NetCoreApp'" Include="MadMilkman.Ini.Unofficial" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\pyRevitLabs.Common\pyRevitLabs.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.RevitCaches.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.RevitCaches.cs
@@ -28,8 +28,8 @@ namespace pyRevitLabs.UnitTests.RevitCaches {
         }
 
         [TestMethod()]
-        public void GetDefaultBIM360CacheDirectory_UsesLocalAppData() {
-            var path = pyRevitLabs.TargetApps.Revit.RevitCaches.GetDefaultBIM360CacheDirectory(2025);
+        public void GetBIM360CacheDirectory_UsesLocalAppDataDefault() {
+            var path = pyRevitLabs.TargetApps.Revit.RevitCaches.GetBIM360CacheDirectory(2025);
             var expectedBase = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
             Assert.IsTrue(path.StartsWith(expectedBase, StringComparison.OrdinalIgnoreCase),
@@ -41,8 +41,8 @@ namespace pyRevitLabs.UnitTests.RevitCaches {
         }
 
         [TestMethod()]
-        public void GetRevitIniPath_UsesAppData() {
-            var path = pyRevitLabs.TargetApps.Revit.RevitCaches.GetRevitIniPath(2024);
+        public void GetRevitIniFile_UsesAppData() {
+            var path = pyRevitLabs.TargetApps.Revit.RevitCaches.GetRevitIniFile(2024);
             var expectedBase = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
             Assert.IsTrue(path.StartsWith(expectedBase, StringComparison.OrdinalIgnoreCase),
@@ -99,13 +99,12 @@ namespace pyRevitLabs.UnitTests.RevitCaches {
         }
 
         [TestMethod()]
-        public void GetCustomBIM360CacheDirectory_UsesExistingPathFor2024Plus() {
-            var cacheDir = Path.Combine(_tempRoot, "cache2025");
-            Directory.CreateDirectory(cacheDir);
-            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={cacheDir}\n");
+        public void GetCustomBIM360CacheDirectory_ReturnsConfiguredPathEvenIfMissing() {
+            var missingDir = Path.Combine(_tempRoot, "does-not-exist");
+            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={missingDir}\n");
 
-            var custom = pyRevitLabs.TargetApps.Revit.RevitCaches.GetCustomBIM360CacheDirectory(2025, iniPath);
-            Assert.AreEqual(Path.GetFullPath(cacheDir), custom);
+            var custom = pyRevitLabs.TargetApps.Revit.RevitCaches.GetCustomBIM360CacheDirectory(2024, iniPath);
+            Assert.AreEqual(Path.GetFullPath(missingDir), custom);
         }
 
         [TestMethod()]
@@ -124,21 +123,34 @@ namespace pyRevitLabs.UnitTests.RevitCaches {
         }
 
         [TestMethod()]
-        public void GetCustomBIM360CacheDirectory_MissingDirectory_ReturnsNull() {
-            var missingDir = Path.Combine(_tempRoot, "does-not-exist");
-            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={missingDir}\n");
+        public void GetActiveBIM360CacheDirectory_UsesExistingCustomPath() {
+            var cacheDir = Path.Combine(_tempRoot, "cache2025");
+            Directory.CreateDirectory(cacheDir);
+            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={cacheDir}\n");
 
-            var custom = pyRevitLabs.TargetApps.Revit.RevitCaches.GetCustomBIM360CacheDirectory(2024, iniPath);
-            Assert.IsNull(custom, "Configured path must exist before it is used");
+            var active = pyRevitLabs.TargetApps.Revit.RevitCaches.GetActiveBIM360CacheDirectory(2025, iniPath);
+            Assert.AreEqual(Path.GetFullPath(cacheDir), active);
         }
 
         [TestMethod()]
-        public void GetBIM360CacheDirectory_FallsBackToDefaultWithoutCustomIni() {
-            // Without a custom ini override, resolution uses the real Revit.ini path.
-            // If that machine has no custom config (typical in CI), expect the default.
-            var resolved = pyRevitLabs.TargetApps.Revit.RevitCaches.GetBIM360CacheDirectory(2022);
-            var expected = pyRevitLabs.TargetApps.Revit.RevitCaches.GetDefaultBIM360CacheDirectory(2022);
-            Assert.AreEqual(expected, resolved);
+        public void GetActiveBIM360CacheDirectory_FallsBackWhenCustomMissing() {
+            var missingDir = Path.Combine(_tempRoot, "does-not-exist");
+            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={missingDir}\n");
+
+            var active = pyRevitLabs.TargetApps.Revit.RevitCaches.GetActiveBIM360CacheDirectory(2024, iniPath);
+            var expected = pyRevitLabs.TargetApps.Revit.RevitCaches.GetBIM360CacheDirectory(2024);
+            Assert.AreEqual(expected, active);
+        }
+
+        [TestMethod()]
+        public void GetActiveBIM360CacheDirectory_Pre2024_UsesDefault() {
+            var cacheDir = Path.Combine(_tempRoot, "cache2023");
+            Directory.CreateDirectory(cacheDir);
+            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={cacheDir}\n");
+
+            var active = pyRevitLabs.TargetApps.Revit.RevitCaches.GetActiveBIM360CacheDirectory(2023, iniPath);
+            var expected = pyRevitLabs.TargetApps.Revit.RevitCaches.GetBIM360CacheDirectory(2023);
+            Assert.AreEqual(expected, active);
         }
 
         private string WriteIni(string contents, string fileName = "Revit.ini") {

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.RevitCaches.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.RevitCaches.cs
@@ -111,6 +111,7 @@ namespace pyRevitLabs.UnitTests.RevitCaches {
         public void GetCustomBIM360CacheDirectory_ExpandsEnvironmentVariables() {
             var cacheDir = Path.Combine(_tempRoot, "envcache");
             Directory.CreateDirectory(cacheDir);
+            var previousValue = Environment.GetEnvironmentVariable("PYREVIT_TEST_BIM360_CACHE");
             Environment.SetEnvironmentVariable("PYREVIT_TEST_BIM360_CACHE", cacheDir);
             try {
                 var iniPath = WriteIni("[CloudModelCache]\nCacheLocation=%PYREVIT_TEST_BIM360_CACHE%\n");
@@ -118,7 +119,7 @@ namespace pyRevitLabs.UnitTests.RevitCaches {
                 Assert.AreEqual(Path.GetFullPath(cacheDir), custom);
             }
             finally {
-                Environment.SetEnvironmentVariable("PYREVIT_TEST_BIM360_CACHE", null);
+                Environment.SetEnvironmentVariable("PYREVIT_TEST_BIM360_CACHE", previousValue);
             }
         }
 

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.RevitCaches.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.RevitCaches.cs
@@ -1,0 +1,150 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+using pyRevitLabs.TargetApps.Revit;
+
+namespace pyRevitLabs.UnitTests.RevitCaches {
+    [TestClass()]
+    public class RevitCachesTests {
+        private string _tempRoot;
+
+        [TestInitialize]
+        public void Setup() {
+            _tempRoot = Path.Combine(Path.GetTempPath(), "pyRevitRevitCachesTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempRoot);
+        }
+
+        [TestCleanup]
+        public void Cleanup() {
+            if (Directory.Exists(_tempRoot)) {
+                try {
+                    Directory.Delete(_tempRoot, recursive: true);
+                }
+                catch {
+                    // best-effort cleanup in temp
+                }
+            }
+        }
+
+        [TestMethod()]
+        public void GetDefaultBIM360CacheDirectory_UsesLocalAppData() {
+            var path = pyRevitLabs.TargetApps.Revit.RevitCaches.GetDefaultBIM360CacheDirectory(2025);
+            var expectedBase = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+            Assert.IsTrue(path.StartsWith(expectedBase, StringComparison.OrdinalIgnoreCase),
+                $"Default cache path should start with {expectedBase}: {path}");
+            Assert.IsTrue(
+                path.EndsWith(Path.Combine("Autodesk", "Revit", "Autodesk Revit 2025", "CollaborationCache"),
+                              StringComparison.OrdinalIgnoreCase),
+                $"Unexpected default cache path: {path}");
+        }
+
+        [TestMethod()]
+        public void GetRevitIniPath_UsesAppData() {
+            var path = pyRevitLabs.TargetApps.Revit.RevitCaches.GetRevitIniPath(2024);
+            var expectedBase = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+
+            Assert.IsTrue(path.StartsWith(expectedBase, StringComparison.OrdinalIgnoreCase),
+                $"Revit.ini path should start with {expectedBase}: {path}");
+            Assert.IsTrue(
+                path.EndsWith(Path.Combine("Autodesk", "Revit", "Autodesk Revit 2024", "Revit.ini"),
+                              StringComparison.OrdinalIgnoreCase),
+                $"Unexpected Revit.ini path: {path}");
+        }
+
+        [TestMethod()]
+        public void ReadCloudModelCacheLocation_ReadsConfiguredValue() {
+            var iniPath = WriteIni(
+                "[CloudModelCache]\n" +
+                "CacheLocation = D:\\Custom\\BIM360Cache\n");
+
+            var value = pyRevitLabs.TargetApps.Revit.RevitCaches.ReadCloudModelCacheLocation(iniPath);
+            Assert.AreEqual(@"D:\Custom\BIM360Cache", value);
+        }
+
+        [TestMethod()]
+        public void ReadCloudModelCacheLocation_StripsQuotesAndIgnoresOtherSections() {
+            var iniPath = WriteIni(
+                "[Other]\n" +
+                "CacheLocation = C:\\Wrong\n" +
+                "[CloudModelCache]\n" +
+                "CacheLocation=\"C:\\Quoted\\Cache\"\n" +
+                "OtherKey=value\n");
+
+            var value = pyRevitLabs.TargetApps.Revit.RevitCaches.ReadCloudModelCacheLocation(iniPath);
+            Assert.AreEqual(@"C:\Quoted\Cache", value);
+        }
+
+        [TestMethod()]
+        public void ReadCloudModelCacheLocation_MissingOrEmpty_ReturnsNull() {
+            Assert.IsNull(pyRevitLabs.TargetApps.Revit.RevitCaches.ReadCloudModelCacheLocation(
+                Path.Combine(_tempRoot, "missing.ini")));
+
+            var emptyIni = WriteIni("[CloudModelCache]\nCacheLocation=\n", "empty.ini");
+            Assert.IsNull(pyRevitLabs.TargetApps.Revit.RevitCaches.ReadCloudModelCacheLocation(emptyIni));
+
+            var noSection = WriteIni("[Directories]\nTempPath=C:\\Temp\n", "nosec.ini");
+            Assert.IsNull(pyRevitLabs.TargetApps.Revit.RevitCaches.ReadCloudModelCacheLocation(noSection));
+        }
+
+        [TestMethod()]
+        public void GetCustomBIM360CacheDirectory_Pre2024_ReturnsNull() {
+            var cacheDir = Path.Combine(_tempRoot, "cache2023");
+            Directory.CreateDirectory(cacheDir);
+            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={cacheDir}\n");
+
+            var custom = pyRevitLabs.TargetApps.Revit.RevitCaches.GetCustomBIM360CacheDirectory(2023, iniPath);
+            Assert.IsNull(custom, "Custom cache paths are only supported for Revit 2024+");
+        }
+
+        [TestMethod()]
+        public void GetCustomBIM360CacheDirectory_UsesExistingPathFor2024Plus() {
+            var cacheDir = Path.Combine(_tempRoot, "cache2025");
+            Directory.CreateDirectory(cacheDir);
+            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={cacheDir}\n");
+
+            var custom = pyRevitLabs.TargetApps.Revit.RevitCaches.GetCustomBIM360CacheDirectory(2025, iniPath);
+            Assert.AreEqual(Path.GetFullPath(cacheDir), custom);
+        }
+
+        [TestMethod()]
+        public void GetCustomBIM360CacheDirectory_ExpandsEnvironmentVariables() {
+            var cacheDir = Path.Combine(_tempRoot, "envcache");
+            Directory.CreateDirectory(cacheDir);
+            Environment.SetEnvironmentVariable("PYREVIT_TEST_BIM360_CACHE", cacheDir);
+            try {
+                var iniPath = WriteIni("[CloudModelCache]\nCacheLocation=%PYREVIT_TEST_BIM360_CACHE%\n");
+                var custom = pyRevitLabs.TargetApps.Revit.RevitCaches.GetCustomBIM360CacheDirectory(2024, iniPath);
+                Assert.AreEqual(Path.GetFullPath(cacheDir), custom);
+            }
+            finally {
+                Environment.SetEnvironmentVariable("PYREVIT_TEST_BIM360_CACHE", null);
+            }
+        }
+
+        [TestMethod()]
+        public void GetCustomBIM360CacheDirectory_MissingDirectory_ReturnsNull() {
+            var missingDir = Path.Combine(_tempRoot, "does-not-exist");
+            var iniPath = WriteIni($"[CloudModelCache]\nCacheLocation={missingDir}\n");
+
+            var custom = pyRevitLabs.TargetApps.Revit.RevitCaches.GetCustomBIM360CacheDirectory(2024, iniPath);
+            Assert.IsNull(custom, "Configured path must exist before it is used");
+        }
+
+        [TestMethod()]
+        public void GetBIM360CacheDirectory_FallsBackToDefaultWithoutCustomIni() {
+            // Without a custom ini override, resolution uses the real Revit.ini path.
+            // If that machine has no custom config (typical in CI), expect the default.
+            var resolved = pyRevitLabs.TargetApps.Revit.RevitCaches.GetBIM360CacheDirectory(2022);
+            var expected = pyRevitLabs.TargetApps.Revit.RevitCaches.GetDefaultBIM360CacheDirectory(2022);
+            Assert.AreEqual(expected, resolved);
+        }
+
+        private string WriteIni(string contents, string fileName = "Revit.ini") {
+            var path = Path.Combine(_tempRoot, fileName);
+            File.WriteAllText(path, contents);
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3488 by teaching the C# `pyrevit caches bim360 clear` path to respect custom collaboration cache locations configured in Revit.ini for Revit 2024+, matching the existing Python `bim360.py` behavior.

This merges Claude’s API shape with the earlier Grok extras:

- Keep `GetBIM360CacheDirectory` as the **default** path (no behavior change for callers)
- Add `GetCustomBIM360CacheDirectory` / `GetActiveBIM360CacheDirectory` for resolution
- Parse Revit.ini with MadMilkman (`FileShare.ReadWrite`) like other Labs config code
- Expand env vars via `CommonUtils.ExpandEnvironmentPath`, normalize with `Path.GetFullPath`, strip quotes
- Clear uses `GetActiveBIM360CacheDirectory` (custom path when present and on disk, else default)
- Unit tests cover INI parsing, version gating, env expansion, and active-path fallback

## Test plan

- [ ] Unit tests in `pyRevitLabs.UnitTests.RevitCaches` pass
- [ ] On a Revit 2024+ machine with custom `CacheLocation`, `pyrevit caches bim360 clear --revit=2025` deletes that custom cache directory
- [ ] Without a custom setting (or for Revit &lt; 2024), clearing still targets the default CollaborationCache path
- [ ] `GetBIM360CacheDirectory` still returns only the default path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54ed49d4-f88a-45d2-bb91-3e79ca8bf4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54ed49d4-f88a-45d2-bb91-3e79ca8bf4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

