### PR TITLE
fix(Convert Line Styles): retire source styles instead of hard-delete (#3385)

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.chinese_s.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.chinese_s.xaml
@@ -11,5 +11,5 @@
     <system:String x:Key="ConvertModelLines">转换模型线</system:String>
     <system:String x:Key="ConvertFilledRegionLines">转换填充区域线（填充区域需要摇动）</system:String>
     <system:String x:Key="ConvertGroupedLines">转换成组线（无 API 支持）</system:String>
-    <system:String x:Key="DeleteConvertedStyles">完成后删除已转换的样式</system:String>
+    <system:String x:Key="RetireConvertedStyles">完成后合并并停用源样式</system:String>
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.de_de.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.de_de.xaml
@@ -11,5 +11,5 @@
     <system:String x:Key="ConvertModelLines">Modell-Linien konvertieren</system:String>
     <system:String x:Key="ConvertFilledRegionLines">Linien von Füllbereichen konvertieren (Füllbereiche müssen geschüttelt werden)</system:String>
     <system:String x:Key="ConvertGroupedLines">Gruppierte Linien konvertieren (Keine API-Unterstützung)</system:String>
-    <system:String x:Key="DeleteConvertedStyles">Konvertierte Stile nach Abschluss löschen</system:String>
+    <system:String x:Key="RetireConvertedStyles">Quellstile nach Abschluss zusammenführen und zurückziehen</system:String>
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.en_us.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.en_us.xaml
@@ -11,5 +11,5 @@
     <system:String x:Key="ConvertModelLines">Convert Model Lines</system:String>
     <system:String x:Key="ConvertFilledRegionLines">Convert Filled Region Lines (Filled Regions Need Shaking)</system:String>
     <system:String x:Key="ConvertGroupedLines">Convert Grouped Lines (No API Support)</system:String>
-    <system:String x:Key="DeleteConvertedStyles">Delete Converted Style(s) When Done</system:String>
+    <system:String x:Key="RetireConvertedStyles">Merge &amp; retire source styles when done</system:String>
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.es_es.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.es_es.xaml
@@ -11,5 +11,5 @@
     <system:String x:Key="ConvertModelLines">Convertir Líneas de Modelo</system:String>
     <system:String x:Key="ConvertFilledRegionLines">Convertir Líneas de Región Rellenada (Las Regiones Rellenadas Necesitan Agitación)</system:String>
     <system:String x:Key="ConvertGroupedLines">Convertir Líneas Agrupadas (Sin Soporte de API)</system:String>
-    <system:String x:Key="DeleteConvertedStyles">Eliminar Estilo(s) Convertido(s) Cuando Termine</system:String>
+    <system:String x:Key="RetireConvertedStyles">Fusionar y retirar estilos de origen al terminar</system:String>
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.fr_fr.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.fr_fr.xaml
@@ -11,5 +11,5 @@
     <system:String x:Key="ConvertModelLines">Convertir les Lignes de Modèle</system:String>
     <system:String x:Key="ConvertFilledRegionLines">Convertir les Lignes de Région Remplie (Les Régions Remplies Nécessitent un Secouement)</system:String>
     <system:String x:Key="ConvertGroupedLines">Convertir les Lignes Groupées (Pas de Support API)</system:String>
-    <system:String x:Key="DeleteConvertedStyles">Supprimer le(s) Style(s) Converti(s) une Fois Terminé</system:String>
+    <system:String x:Key="RetireConvertedStyles">Fusionner et retirer les styles source une fois terminé</system:String>
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.ko.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.ko.xaml
@@ -11,5 +11,5 @@
     <system:String x:Key="ConvertModelLines">모델 선 변환</system:String>
     <system:String x:Key="ConvertFilledRegionLines">채워진 영역 선 변환 (채워진 영역 흔들기 필요)</system:String>
     <system:String x:Key="ConvertGroupedLines">그룹화된 선 변환 (API 지원 없음)</system:String>
-    <system:String x:Key="DeleteConvertedStyles">완료 후 변환된 스타일 삭제</system:String>
+    <system:String x:Key="RetireConvertedStyles">완료 시 원본 스타일 병합 및 폐기</system:String>
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.pt_br.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.pt_br.xaml
@@ -11,5 +11,5 @@
     <system:String x:Key="ConvertModelLines">Converter Linhas de Modelo</system:String>
     <system:String x:Key="ConvertFilledRegionLines">Converter Linhas de Região Preenchida (Regiões Preenchidas Precisam ser Regeneradas)</system:String>
     <system:String x:Key="ConvertGroupedLines">Converter Linhas Agrupadas (Sem Suporte API)</system:String>
-    <system:String x:Key="DeleteConvertedStyles">Excluir Estilo(s) Convertido(s) ao Concluir</system:String>
+    <system:String x:Key="RetireConvertedStyles">Mesclar e aposentar estilos de origem ao concluir</system:String>
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.ru.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.ResourceDictionary.ru.xaml
@@ -11,5 +11,5 @@
     <system:String x:Key="ConvertModelLines">Преобразовать модели линии</system:String>
     <system:String x:Key="ConvertFilledRegionLines">Преобразовать линии заполненных областей (Заполненные области требуют встряхивания)</system:String>
     <system:String x:Key="ConvertGroupedLines">Преобразовать сгруппированные линии (Нет поддержки API)</system:String>
-    <system:String x:Key="DeleteConvertedStyles">Удалить преобразованные стили после завершения</system:String>
+    <system:String x:Key="RetireConvertedStyles">Объединить и вывести исходные стили по завершении</system:String>
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.xaml
@@ -72,7 +72,7 @@
                     <CheckBox x:Name="convertSketchLines" Margin="0,5,0,0" IsChecked="False" Content="{DynamicResource ConvertFilledRegionLines}" />
                     <!--<CheckBox x:Name="shakeFilledRegions" Margin="0,5,0,0" IsChecked="False" Content="Shake Filled Regions (Could take a long time)" IsEnabled="{Binding ElementName=convertSketchLines, Path=IsChecked}"/>-->
                     <CheckBox x:Name="convertGroupedLines" Margin="0,5,0,0" IsChecked="False" IsEnabled="False" Content="{DynamicResource ConvertGroupedLines}" />
-                    <CheckBox x:Name="deleteFromStyle" Margin="0,5,0,0" IsChecked="False" Content="{DynamicResource RetireConvertedStyles}" />
+                    <CheckBox x:Name="retireFromStyle" Margin="0,5,0,0" IsChecked="False" Content="{DynamicResource RetireConvertedStyles}" />
                 </StackPanel>
             </GroupBox>
             <!--<StackPanel DockPanel.Dock="Right" Width="30" Margin="10,0,0,0">

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/ConvertLineStyles.xaml
@@ -72,7 +72,7 @@
                     <CheckBox x:Name="convertSketchLines" Margin="0,5,0,0" IsChecked="False" Content="{DynamicResource ConvertFilledRegionLines}" />
                     <!--<CheckBox x:Name="shakeFilledRegions" Margin="0,5,0,0" IsChecked="False" Content="Shake Filled Regions (Could take a long time)" IsEnabled="{Binding ElementName=convertSketchLines, Path=IsChecked}"/>-->
                     <CheckBox x:Name="convertGroupedLines" Margin="0,5,0,0" IsChecked="False" IsEnabled="False" Content="{DynamicResource ConvertGroupedLines}" />
-                    <CheckBox x:Name="deleteFromStyle" Margin="0,5,0,0" IsChecked="False" Content="{DynamicResource DeleteConvertedStyles}" />
+                    <CheckBox x:Name="deleteFromStyle" Margin="0,5,0,0" IsChecked="False" Content="{DynamicResource RetireConvertedStyles}" />
                 </StackPanel>
             </GroupBox>
             <!--<StackPanel DockPanel.Dock="Right" Width="30" Margin="10,0,0,0">

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/script.py
@@ -405,7 +405,7 @@ class ConvertLineStylesWindow(forms.WPFWindow):
                 for eline in editable_lines:
                     style_convert.convert_style(eline)
 
-            if self.deleteFromStyle.IsChecked:
+            if self.retireFromStyle.IsChecked:
                 self._remap_remaining_curve_styles(self.line_converts)
                 self._remap_mep_hidden_line_styles(self.line_converts)
                 self.retire_linecats(self.line_converts)

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/script.py
@@ -4,6 +4,11 @@ select a line with the interfacetypes style.
 The script will correct the line styles in the model.
 HOWEVER the lines that are part of a group will not be affected.
 Also see the "Shake Filled Regions" tool.
+
+When retiring source styles, categories are kept (renamed + appearance
+matched to the target) so Linework overrides that still reference them
+do not leave the model in a crash-prone state. Hard deletion is unsafe
+because the Revit API cannot remap Linework edge overrides.
 """
 #pylint: disable=import-error,invalid-name,unused-argument,broad-except
 from pyrevit.framework import List
@@ -14,6 +19,7 @@ from pyrevit.compat import get_elementid_value_func
 
 
 NO_COLOR_COLOR = '#000000'
+RETIRE_PREFIX = 'zz_merged -> '
 
 
 logger = script.get_logger()
@@ -237,23 +243,155 @@ class ConvertLineStylesWindow(forms.WPFWindow):
     def convert_down(self, sender, args):
         pass
 
-    def delete_linecats(self, line_converts):
+    def _collect_line_categories(self):
+        lines_cat = revit.doc.Settings.Categories.get_Item(
+            DB.BuiltInCategory.OST_Lines
+            )
+        return list(lines_cat.SubCategories)
+
+    def _unique_retire_name(self, from_name, to_name, existing_names):
+        base = '{}{} => {}'.format(RETIRE_PREFIX, from_name, to_name)
+        name = base
+        index = 2
+        while name in existing_names:
+            name = '{} ({})'.format(base, index)
+            index += 1
+        return name
+
+    def _copy_category_graphics(self, from_cat, to_cat):
+        for style_type in (DB.GraphicsStyleType.Projection,
+                           DB.GraphicsStyleType.Cut):
+            try:
+                weight = to_cat.GetLineWeight(style_type)
+                if weight and weight > 0:
+                    from_cat.SetLineWeight(weight, style_type)
+            except Exception as ex:
+                logger.debug(
+                    'Failed copying line weight for \"%s\" | %s',
+                    from_cat.Name, ex
+                    )
+            try:
+                pattern_id = to_cat.GetLinePatternId(style_type)
+                if pattern_id and pattern_id != DB.ElementId.InvalidElementId:
+                    from_cat.SetLinePatternId(pattern_id, style_type)
+            except Exception as ex:
+                logger.debug(
+                    'Failed copying line pattern for \"%s\" | %s',
+                    from_cat.Name, ex
+                    )
+        try:
+            if to_cat.LineColor and to_cat.LineColor.IsValid:
+                from_cat.LineColor = to_cat.LineColor
+        except Exception as ex:
+            logger.debug(
+                'Failed copying line color for \"%s\" | %s',
+                from_cat.Name, ex
+                )
+
+    def _remap_mep_hidden_line_styles(self, line_converts):
+        # Project MEP hidden-line setting can reference a custom style; deleting
+        # that style without remapping can destabilize the document.
+        try:
+            mep_settings = DB.MEPHiddenLineSettings.GetMEPHiddenLineSettings(
+                revit.doc
+                )
+        except Exception:
+            return
+
+        if not mep_settings:
+            return
+
+        current_id = mep_settings.LineStyle
+        if not current_id or current_id == DB.ElementId.InvalidElementId:
+            return
+
+        current_value = get_elementid_value(current_id)
         for style_convert in line_converts:
             for from_style in style_convert.from_styles:
-                line_cat = from_style.category
-                if line_cat:
+                if get_elementid_value(from_style.style.Id) == current_value:
                     try:
-                        revit.doc.Delete(line_cat.Id)
-                    except Exception as ex:
-                        if get_elementid_value(line_cat.Id) < 0:
-                            logger.error(
-                                'Can not remove builtin line style \"%s\"',
-                                line_cat.Name
-                                )
-                        logger.debug(
-                            'Failed removing line category \"%s\" | %s',
-                            line_cat.Name, ex
+                        mep_settings.LineStyle = style_convert.to_style.style.Id
+                        logger.info(
+                            'Remapped MEP hidden line style \"%s\" -> \"%s\"',
+                            from_style.name,
+                            style_convert.to_style.name
                             )
+                    except Exception as ex:
+                        logger.warning(
+                            'Could not remap MEP hidden line style \"%s\" | %s',
+                            from_style.name, ex
+                            )
+                    return
+
+    def _remap_remaining_curve_styles(self, line_converts):
+        # Convert any leftover CurveElements still on source styles (e.g. types
+        # skipped by convert options). Grouped curves may refuse edits.
+        from_names = {}
+        for style_convert in line_converts:
+            for from_style in style_convert.from_styles:
+                from_names[from_style.name] = style_convert.to_style.style
+
+        if not from_names:
+            return
+
+        curves = DB.FilteredElementCollector(revit.doc)\
+            .OfClass(DB.CurveElement)\
+            .WhereElementIsNotElementType()\
+            .ToElements()
+
+        for curve in curves:
+            try:
+                style_name = curve.LineStyle.Name
+            except Exception:
+                continue
+            to_style = from_names.get(style_name)
+            if not to_style:
+                continue
+            try:
+                curve.LineStyle = to_style
+            except Exception as ex:
+                logger.debug(
+                    'Could not remap curve %s style \"%s\" | %s',
+                    get_elementid_value(curve.Id), style_name, ex
+                    )
+
+    def retire_linecats(self, line_converts):
+        """Match source style look to target and rename; keep ElementIds."""
+        existing_names = set(
+            cat.Name for cat in self._collect_line_categories()
+            )
+
+        for style_convert in line_converts:
+            to_cat = style_convert.to_style.category
+            for from_style in style_convert.from_styles:
+                from_cat = from_style.category
+                if not from_cat:
+                    continue
+                if get_elementid_value(from_cat.Id) < 0:
+                    logger.warning(
+                        'Skipping builtin line style \"%s\"',
+                        from_cat.Name
+                        )
+                    continue
+                old_name = from_cat.Name
+                try:
+                    self._copy_category_graphics(from_cat, to_cat)
+                    new_name = self._unique_retire_name(
+                        old_name,
+                        style_convert.to_style.name,
+                        existing_names
+                        )
+                    from_cat.Name = new_name
+                    existing_names.add(new_name)
+                    logger.info(
+                        'Retired line style \"%s\" as \"%s\"',
+                        old_name, new_name
+                        )
+                except Exception as ex:
+                    logger.warning(
+                        'Failed retiring line style \"%s\" | %s',
+                        old_name, ex
+                        )
 
     def convert_styles(self, sender, args):
         self.Close()
@@ -264,7 +402,9 @@ class ConvertLineStylesWindow(forms.WPFWindow):
                     style_convert.convert_style(eline)
 
             if self.deleteFromStyle.IsChecked:
-                self.delete_linecats(self.line_converts)
+                self._remap_remaining_curve_styles(self.line_converts)
+                self._remap_mep_hidden_line_styles(self.line_converts)
+                self.retire_linecats(self.line_converts)
 
 
 if __name__ == '__main__':

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/script.py
@@ -340,6 +340,10 @@ class ConvertLineStylesWindow(forms.WPFWindow):
             .ToElements()
 
         for curve in curves:
+            # keep grouped curves unchanged (consistent with primary conversion pass)
+            if curve.GroupId is not None \
+                    and curve.GroupId != DB.ElementId.InvalidElementId:
+                continue
             try:
                 style_name = curve.LineStyle.Name
             except Exception:

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Modify.panel/edit3.stack/Edit.pulldown/Convert Line Styles.pushbutton/script.py
@@ -272,7 +272,7 @@ class ConvertLineStylesWindow(forms.WPFWindow):
                     )
             try:
                 pattern_id = to_cat.GetLinePatternId(style_type)
-                if pattern_id and pattern_id != DB.ElementId.InvalidElementId:
+                if pattern_id is not None:
                     from_cat.SetLinePatternId(pattern_id, style_type)
             except Exception as ex:
                 logger.debug(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hard-deleting converted line styles crashes Revit when Linework overrides still reference them. The Revit API cannot remap Linework edges, so this replaces unsafe deletion with a safe merge/retire path.

### Changes
- Convert CurveElements as before
- When “Merge & retire source styles when done” is checked:
  - Remap leftover CurveElements still on source styles (skips grouped curves)
  - Remap `MEPHiddenLineSettings.LineStyle` when it points at a source style
  - Copy target weight/color/pattern onto the source category and rename it (`zz_merged -> …`)
  - Keep the category ElementId so Linework refs stay valid (no crash)
- Renamed checkbox `deleteFromStyle` → `retireFromStyle` (XAML + script) so wiring matches behavior
- Builtin styles are skipped; locales updated for the new checkbox label

### Not in scope
True purge of retired styles still requires manually clearing Linework first (API gap).

Fixes #3385

Alternative to #3503 (which only disabled the checkbox).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4d850b4-a4c7-4b16-b781-49a061a7b6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4d850b4-a4c7-4b16-b781-49a061a7b6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

