### PR TITLE
Add WWPTools extension to extensions list

### DIFF
--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -86,7 +86,7 @@
             "rocket_mode_compatible": "True",
             "name": "MEPDesign",
             "description": "Extensions for Revit MEP",
-            "author": "André Rodrigues da Silva",
+            "author": "Andr\u00e9 Rodrigues da Silva",
             "author_profile": "https://github.com/andrerdsilva",
             "url": "https://github.com/andrerdsilva/MEPDesign.git",
             "website": "http://engenheirohidraulico.com.br/",
@@ -329,6 +329,19 @@
             "url": "https://github.com/lewismconte/blendit.git",
             "website": "https://github.com/lewismconte/blendit",
             "image": "https://raw.githubusercontent.com/lewismconte/blendit/main/media/blendit_hero.png",
+            "dependencies": []
+        },
+        {
+            "builtin": "False",
+            "type": "extension",
+            "rocket_mode_compatible": "False",
+            "name": "WWPTools",
+            "description": "WWPTools is a comprehensive Revit productivity toolbar (Setup, Context, Manage, Sheets, Cleanup panels) developed by WWP Architects + Planners.",
+            "author": "Jason Tian",
+            "author_profile": "https://github.com/jason-svn",
+            "url": "https://github.com/WWP-Architects-Planners/WWP_Revit_WWPTools.git",
+            "website": "https://github.com/WWP-Architects-Planners/WWP_Revit_WWPTools",
+            "image": "",
             "dependencies": []
         }
     ]


### PR DESCRIPTION
## Summary
Adds WWPTools to `extensions/extensions.json` following the format documented in [Share Your Extensions](https://pyrevitlabs.notion.site/Share-Your-Extensions-48ff84d4eae846f4aa9567fca32ff4fe).

- **Name:** WWPTools
- **Repo:** https://github.com/jason-svn/WWPTools_Publicly_Shared
- **Description:** Comprehensive Revit productivity toolbar (Setup, Context, Manage, Sheets, Cleanup panels).
- Distributed as a pyRevit git extension (clone-based install/update), actively maintained with tagged releases.

## Test plan
- [x] Validated JSON is well-formed and matches existing entry schema
- [x] Confirmed no duplicate entry already exists for WWPTools
- [ ] Maintainer review of listing content