### PR TITLE
Update WWPTools extension entry to personal repo

### DIFF
--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -336,11 +336,11 @@
             "type": "extension",
             "rocket_mode_compatible": "False",
             "name": "WWPTools",
-            "description": "WWPTools is a comprehensive Revit productivity toolbar (Setup, Context, Manage, Sheets, Cleanup panels) developed by WWP Architects + Planners.",
+            "description": "Comprehensive Revit productivity toolbar (Setup, Context, Manage, Sheets, Cleanup panels).",
             "author": "Jason Tian",
             "author_profile": "https://github.com/jason-svn",
-            "url": "https://github.com/WWP-Architects-Planners/WWP_Revit_WWPTools.git",
-            "website": "https://github.com/WWP-Architects-Planners/WWP_Revit_WWPTools",
+            "url": "https://github.com/jason-svn/WWPTools_Publicly_Shared.git",
+            "website": "https://github.com/jason-svn/WWPTools_Publicly_Shared",
             "image": "",
             "dependencies": []
         }


### PR DESCRIPTION
## Summary
Follow-up to #3507, which merged before I could push a requested change. Updates the WWPTools entry in `extensions/extensions.json` to point to my personal repo instead of my employer's org, since I want to distribute/maintain this listing independently of my company's GitHub org.

- **url:** `https://github.com/WWP-Architects-Planners/WWP_Revit_WWPTools.git` → `https://github.com/jason-svn/WWPTools_Publicly_Shared.git`
- **website:** same change
- **description:** removed company name reference

The personal repo is a full mirror (history + tags) of the original, so the extension itself is unchanged for end users — just the source/attribution.

## Test plan
- [x] Validated JSON is well-formed
- [x] Confirmed personal repo is a working pyRevit git extension (same file layout as original)
- [ ] Maintainer review