### PR TITLE
fix: keep admin-install config writable in AppData for standard users

### DIFF
--- a/dev/pyRevitLabs/pyRevitLabs.Common/PyRevitInstallScope.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/PyRevitInstallScope.cs
@@ -99,12 +99,11 @@ namespace pyRevitLabs.Common {
         /// <summary>
         /// Resolves the configuration file the current process should use.
         /// A machine-wide config marked with the ReadOnly attribute is a deliberate
-        /// admin lock and is used as-is in read-only mode. For all-users installs
-        /// the machine-wide config is writable only from an elevated process
-        /// (installer or admin CLI); standard users always get a per-user config
-        /// under AppData, seeded from the machine-wide file when one exists.
-        /// Per-user installs always resolve to AppData unless the admin lock above
-        /// applies.
+        /// admin lock and is used as-is in read-only mode. For all-users installs,
+        /// elevated processes (installer / admin CLI) always target ProgramData;
+        /// standard users always get a per-user config under AppData, seeded from
+        /// the machine-wide file when one exists. Per-user installs always resolve
+        /// to AppData unless the admin lock above applies.
         /// </summary>
         public static ActiveConfigInfo GetActiveConfig(bool createIfMissing = true) {
             var machineRoot = PyRevitLabsConsts.PyRevitProgramDataPath;
@@ -118,10 +117,11 @@ namespace pyRevitLabs.Common {
 
             if (IsAllUsersInstall() && IsElevatedProcess()) {
                 if (machineConfigExists) {
-                    if (IsFileWritable(machineConfig))
-                        return new ActiveConfigInfo(machineConfig, isReadOnly: false, isMachineConfig: true);
+                    bool writable = IsFileWritable(machineConfig);
+                    return new ActiveConfigInfo(
+                        machineConfig, isReadOnly: !writable, isMachineConfig: true);
                 }
-                else if (!createIfMissing || TryCreateFile(machineConfig)) {
+                if (!createIfMissing || TryCreateFile(machineConfig)) {
                     return new ActiveConfigInfo(machineConfig, isReadOnly: false, isMachineConfig: true);
                 }
             }

--- a/dev/pyRevitLabs/pyRevitLabs.Common/PyRevitInstallScope.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/PyRevitInstallScope.cs
@@ -172,6 +172,9 @@ namespace pyRevitLabs.Common {
                 }
             }
 
+            if (File.Exists(userConfig))
+                return;
+
             TryCreateFile(userConfig);
         }
 

--- a/dev/pyRevitLabs/pyRevitLabs.Common/PyRevitInstallScope.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/PyRevitInstallScope.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace pyRevitLabs.Common {
@@ -99,10 +100,11 @@ namespace pyRevitLabs.Common {
         /// Resolves the configuration file the current process should use.
         /// A machine-wide config marked with the ReadOnly attribute is a deliberate
         /// admin lock and is used as-is in read-only mode. For all-users installs
-        /// the machine-wide config is used directly only when the process can
-        /// actually write to it (e.g. an elevated installer or CLI); otherwise the
-        /// per-user config is used, seeded from the machine-wide config on first
-        /// run, so standard users can still save their own settings.
+        /// the machine-wide config is writable only from an elevated process
+        /// (installer or admin CLI); standard users always get a per-user config
+        /// under AppData, seeded from the machine-wide file when one exists.
+        /// Per-user installs always resolve to AppData unless the admin lock above
+        /// applies.
         /// </summary>
         public static ActiveConfigInfo GetActiveConfig(bool createIfMissing = true) {
             var machineRoot = PyRevitLabsConsts.PyRevitProgramDataPath;
@@ -114,12 +116,10 @@ namespace pyRevitLabs.Common {
             if (machineConfigExists && HasReadOnlyAttribute(machineConfig))
                 return new ActiveConfigInfo(machineConfig, isReadOnly: true, isMachineConfig: true);
 
-            if (IsAllUsersInstall()) {
+            if (IsAllUsersInstall() && IsElevatedProcess()) {
                 if (machineConfigExists) {
                     if (IsFileWritable(machineConfig))
                         return new ActiveConfigInfo(machineConfig, isReadOnly: false, isMachineConfig: true);
-                    // ACL-restricted machine config (e.g. created by the elevated
-                    // installer): fall through to a per-user config seeded from it
                 }
                 else if (!createIfMissing || TryCreateFile(machineConfig)) {
                     return new ActiveConfigInfo(machineConfig, isReadOnly: false, isMachineConfig: true);
@@ -127,6 +127,17 @@ namespace pyRevitLabs.Common {
             }
 
             return GetUserConfig(machineConfigExists ? machineConfig : null, createIfMissing);
+        }
+
+        /// <summary>
+        /// True when the current Windows process is elevated (installer / admin CLI).
+        /// Always false on non-Windows hosts so CI and cross-platform tooling
+        /// resolve to the per-user config path.
+        /// </summary>
+        private static bool IsElevatedProcess() {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return false;
+            return UserEnv.IsRunAsElevated();
         }
 
         private static ActiveConfigInfo GetUserConfig(string seedConfig, bool createIfMissing) {
@@ -150,8 +161,8 @@ namespace pyRevitLabs.Common {
                 }
             }
 
-bool isReadOnly = !File.Exists(userConfig) || !IsFileWritable(userConfig);
-return new ActiveConfigInfo(userConfig, isReadOnly, isMachineConfig: false);
+            bool isReadOnly = !File.Exists(userConfig) || !IsFileWritable(userConfig);
+            return new ActiveConfigInfo(userConfig, isReadOnly, isMachineConfig: false);
         }
 
         /// <summary>True when the file carries the DOS ReadOnly attribute (deliberate admin lock).</summary>

--- a/dev/pyRevitLabs/pyRevitLabs.Common/PyRevitInstallScope.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/PyRevitInstallScope.cs
@@ -145,24 +145,34 @@ namespace pyRevitLabs.Common {
             var userConfig = FindConfigIniInDirectory(userRoot)
                 ?? Path.Combine(userRoot, PyRevitLabsConsts.DefaultConfigsFileName);
 
-            if (createIfMissing && !File.Exists(userConfig)) {
-                try {
-                    var directory = Path.GetDirectoryName(userConfig);
-                    if (!string.IsNullOrEmpty(directory))
-                        Directory.CreateDirectory(directory);
-                    if (seedConfig != null)
-                        File.Copy(seedConfig, userConfig, overwrite: false);
-                    else
-                        File.Create(userConfig).Dispose();
-                }
-                catch {
-                    // fall through; callers get a read-only view when the file exists,
-                    // or handle the missing file themselves
-                }
-            }
+            if (createIfMissing && !File.Exists(userConfig))
+                EnsureUserConfigFile(userConfig, seedConfig);
 
             bool isReadOnly = !File.Exists(userConfig) || !IsFileWritable(userConfig);
             return new ActiveConfigInfo(userConfig, isReadOnly, isMachineConfig: false);
+        }
+
+        private static void EnsureUserConfigFile(string userConfig, string seedConfig) {
+            try {
+                var directory = Path.GetDirectoryName(userConfig);
+                if (!string.IsNullOrEmpty(directory))
+                    Directory.CreateDirectory(directory);
+            }
+            catch {
+                // fall through; TryCreateFile reports failure when the path is unusable
+            }
+
+            if (seedConfig != null) {
+                try {
+                    File.Copy(seedConfig, userConfig, overwrite: false);
+                    return;
+                }
+                catch {
+                    // seed unreadable or copy blocked: still give the user a writable ini
+                }
+            }
+
+            TryCreateFile(userConfig);
         }
 
         /// <summary>True when the file carries the DOS ReadOnly attribute (deliberate admin lock).</summary>

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.PyRevitInstallScope.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.PyRevitInstallScope.cs
@@ -255,10 +255,11 @@ namespace pyRevitLabs.UnitTests {
         }
 
         [TestMethod]
-        public void GetActiveConfig_AllUsers_UnwritableMachineConfig_FallsBackToSeededUserConfig() {
+        public void GetActiveConfig_AllUsers_UnwritableMachineConfig_NonElevated_FallsBackToSeededUserConfig() {
             if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
                     System.Runtime.InteropServices.OSPlatform.Windows))
                 Assert.Inconclusive("File sharing violations are only enforced on Windows.");
+            AssertRequiresNonElevatedWindowsProcess();
 
             Environment.SetEnvironmentVariable(
                 PyRevitInstallScope.ConfigScopeEnvVar,
@@ -283,6 +284,33 @@ namespace pyRevitLabs.UnitTests {
                 Assert.IsFalse(active.IsReadOnly);
                 Assert.IsTrue(File.Exists(expectedUserConfig));
                 Assert.AreEqual(seedContent, File.ReadAllText(expectedUserConfig));
+            }
+        }
+
+        [TestMethod]
+        public void GetActiveConfig_AllUsers_UnwritableMachineConfig_Elevated_UsesMachineConfig() {
+            if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                    System.Runtime.InteropServices.OSPlatform.Windows))
+                Assert.Inconclusive("File sharing violations are only enforced on Windows.");
+            if (!UserEnv.IsRunAsElevated())
+                Assert.Inconclusive("Test requires an elevated Windows process.");
+
+            Environment.SetEnvironmentVariable(
+                PyRevitInstallScope.ConfigScopeEnvVar,
+                PyRevitInstallScope.ConfigScopeAllUsers);
+            PyRevitInstallScope.ClearCachedInstallScope();
+
+            string machineConfig = Path.Combine(
+                PyRevitLabsConsts.PyRevitProgramDataPath, PyRevitLabsConsts.DefaultConfigsFileName);
+            Directory.CreateDirectory(PyRevitLabsConsts.PyRevitProgramDataPath);
+            File.WriteAllText(machineConfig, "[core]\r\n");
+
+            using (File.Open(machineConfig, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                var active = PyRevitInstallScope.GetActiveConfig();
+
+                Assert.AreEqual(machineConfig, active.ConfigPath);
+                Assert.IsTrue(active.IsMachineConfig);
+                Assert.IsTrue(active.IsReadOnly);
             }
         }
 

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.PyRevitInstallScope.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.PyRevitInstallScope.cs
@@ -101,8 +101,17 @@ namespace pyRevitLabs.UnitTests {
             }
         }
 
+        private static void AssertRequiresNonElevatedWindowsProcess() {
+            if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                    System.Runtime.InteropServices.OSPlatform.Windows))
+                return;
+            if (UserEnv.IsRunAsElevated())
+                Assert.Inconclusive("Test requires a non-elevated Windows process.");
+        }
+
         [TestMethod]
         public void GetActiveConfig_AllUsers_WritableMachineConfig_NonElevated_UsesUserConfig() {
+            AssertRequiresNonElevatedWindowsProcess();
             Environment.SetEnvironmentVariable(
                 PyRevitInstallScope.ConfigScopeEnvVar,
                 PyRevitInstallScope.ConfigScopeAllUsers);
@@ -150,6 +159,7 @@ namespace pyRevitLabs.UnitTests {
 
         [TestMethod]
         public void GetActiveConfig_AllUsers_MissingMachineConfig_NonElevated_CreatesUserConfig() {
+            AssertRequiresNonElevatedWindowsProcess();
             Environment.SetEnvironmentVariable(
                 PyRevitInstallScope.ConfigScopeEnvVar,
                 PyRevitInstallScope.ConfigScopeAllUsers);
@@ -187,6 +197,37 @@ namespace pyRevitLabs.UnitTests {
             Assert.IsTrue(active.IsMachineConfig);
             Assert.IsFalse(active.IsReadOnly);
             Assert.IsTrue(File.Exists(expected));
+        }
+
+        [TestMethod]
+        public void GetActiveConfig_AllUsers_UnreadableMachineSeed_CreatesWritableUserConfig() {
+            if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                    System.Runtime.InteropServices.OSPlatform.Windows))
+                Assert.Inconclusive("Exclusive file sharing is only enforced on Windows.");
+            AssertRequiresNonElevatedWindowsProcess();
+
+            Environment.SetEnvironmentVariable(
+                PyRevitInstallScope.ConfigScopeEnvVar,
+                PyRevitInstallScope.ConfigScopeAllUsers);
+            PyRevitInstallScope.ClearCachedInstallScope();
+
+            string machineConfig = Path.Combine(
+                PyRevitLabsConsts.PyRevitProgramDataPath, PyRevitLabsConsts.DefaultConfigsFileName);
+            Directory.CreateDirectory(PyRevitLabsConsts.PyRevitProgramDataPath);
+            const string seedContent = "[core]\r\ncheckupdates = false\r\n";
+            File.WriteAllText(machineConfig, seedContent);
+
+            // exclusive share blocks seeding but must not block creating a user ini
+            using (File.Open(machineConfig, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) {
+                var active = PyRevitInstallScope.GetActiveConfig();
+
+                string expectedUserConfig = Path.Combine(
+                    PyRevitLabsConsts.PyRevitPath, PyRevitLabsConsts.DefaultConfigsFileName);
+                Assert.AreEqual(expectedUserConfig, active.ConfigPath);
+                Assert.IsFalse(active.IsMachineConfig);
+                Assert.IsFalse(active.IsReadOnly);
+                Assert.IsTrue(File.Exists(expectedUserConfig));
+            }
         }
 
         [TestMethod]

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.PyRevitInstallScope.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.PyRevitInstallScope.cs
@@ -102,7 +102,36 @@ namespace pyRevitLabs.UnitTests {
         }
 
         [TestMethod]
-        public void GetActiveConfig_AllUsers_WritableMachineConfig_UsesMachineConfig() {
+        public void GetActiveConfig_AllUsers_WritableMachineConfig_NonElevated_UsesUserConfig() {
+            Environment.SetEnvironmentVariable(
+                PyRevitInstallScope.ConfigScopeEnvVar,
+                PyRevitInstallScope.ConfigScopeAllUsers);
+            PyRevitInstallScope.ClearCachedInstallScope();
+
+            string machineConfig = Path.Combine(
+                PyRevitLabsConsts.PyRevitProgramDataPath, PyRevitLabsConsts.DefaultConfigsFileName);
+            Directory.CreateDirectory(PyRevitLabsConsts.PyRevitProgramDataPath);
+            const string seedContent = "[core]\r\ncheckupdates = false\r\n";
+            File.WriteAllText(machineConfig, seedContent);
+
+            var active = PyRevitInstallScope.GetActiveConfig();
+            string expectedUserConfig = Path.Combine(
+                PyRevitLabsConsts.PyRevitPath, PyRevitLabsConsts.DefaultConfigsFileName);
+            Assert.AreEqual(expectedUserConfig, active.ConfigPath);
+            Assert.IsFalse(active.IsMachineConfig);
+            Assert.IsFalse(active.IsReadOnly);
+            Assert.IsTrue(File.Exists(expectedUserConfig));
+            Assert.AreEqual(seedContent, File.ReadAllText(expectedUserConfig));
+        }
+
+        [TestMethod]
+        public void GetActiveConfig_AllUsers_WritableMachineConfig_Elevated_UsesMachineConfig() {
+            if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                    System.Runtime.InteropServices.OSPlatform.Windows))
+                Assert.Inconclusive("Elevation detection is only available on Windows.");
+            if (!UserEnv.IsRunAsElevated())
+                Assert.Inconclusive("Test requires an elevated Windows process.");
+
             Environment.SetEnvironmentVariable(
                 PyRevitInstallScope.ConfigScopeEnvVar,
                 PyRevitInstallScope.ConfigScopeAllUsers);
@@ -120,7 +149,32 @@ namespace pyRevitLabs.UnitTests {
         }
 
         [TestMethod]
-        public void GetActiveConfig_AllUsers_MissingMachineConfig_CreatesMachineConfig() {
+        public void GetActiveConfig_AllUsers_MissingMachineConfig_NonElevated_CreatesUserConfig() {
+            Environment.SetEnvironmentVariable(
+                PyRevitInstallScope.ConfigScopeEnvVar,
+                PyRevitInstallScope.ConfigScopeAllUsers);
+            PyRevitInstallScope.ClearCachedInstallScope();
+
+            var active = PyRevitInstallScope.GetActiveConfig();
+            string expectedUserConfig = Path.Combine(
+                PyRevitLabsConsts.PyRevitPath, PyRevitLabsConsts.DefaultConfigsFileName);
+            string expectedMachineConfig = Path.Combine(
+                PyRevitLabsConsts.PyRevitProgramDataPath, PyRevitLabsConsts.DefaultConfigsFileName);
+            Assert.AreEqual(expectedUserConfig, active.ConfigPath);
+            Assert.IsFalse(active.IsMachineConfig);
+            Assert.IsFalse(active.IsReadOnly);
+            Assert.IsTrue(File.Exists(expectedUserConfig));
+            Assert.IsFalse(File.Exists(expectedMachineConfig));
+        }
+
+        [TestMethod]
+        public void GetActiveConfig_AllUsers_MissingMachineConfig_Elevated_CreatesMachineConfig() {
+            if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                    System.Runtime.InteropServices.OSPlatform.Windows))
+                Assert.Inconclusive("Elevation detection is only available on Windows.");
+            if (!UserEnv.IsRunAsElevated())
+                Assert.Inconclusive("Test requires an elevated Windows process.");
+
             Environment.SetEnvironmentVariable(
                 PyRevitInstallScope.ConfigScopeEnvVar,
                 PyRevitInstallScope.ConfigScopeAllUsers);

--- a/release/pyrevit-admin.iss
+++ b/release/pyrevit-admin.iss
@@ -123,8 +123,6 @@ begin
       'Run the following from an elevated command prompt in the install bin folder:' + #13#10 +
       '  pyrevit attach master default --installed --allusers',
       mbError, MB_OK);
-  if not RunPyRevitCommand('configs seedshippeddefaults', False) then
-    Log('pyrevit configs seedshippeddefaults failed or was skipped');
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes the enterprise deployment issue reported by David Baldacchino where admin (all-users) installs write `pyRevit_config.ini` to `%ProgramData%\pyRevit\`, causing launch failures for non-admin users and multi-user conflicts on shared machines (Citrix, walk-up stations).

PR #3512 already added a fallback when the ProgramData file is ACL-restricted, but standard users could still end up with a writable ProgramData config when the file was missing or owned by a prior user. ProgramData should be a read-only seed; `%AppData%\pyRevit` should hold each user's writable copy.

### Changes

**`PyRevitInstallScope.GetActiveConfig()`**
- **Admin install, elevated process** (installer / admin CLI): may create or write `%ProgramData%\pyRevit\pyRevit_config.ini` — unchanged for migration and `pyrevit configs seed` workflows.
- **Admin install, standard user** (Revit launch): always resolves to `%AppData%\pyRevit\pyRevit_config.ini`, seeded from any existing ProgramData ini.
- **Per-user install**: unchanged — always AppData unless an admin-locked ProgramData seed (`pyrevit configs seed --lock`) is present.

**`PyRevitInstallScope.EnsureUserConfigFile()`**
- When seeding from ProgramData fails (ACL, lock, unreadable seed), falls back to creating an empty writable user ini instead of leaving no file behind.

**Admin installer (`pyrevit-admin.iss`)**
- Removed `configs seedshippeddefaults` from post-install. This prevents SCCM/admin deployments from leaving a SYSTEM-owned ini in ProgramData. Extension opt-out defaults are already enforced from `extension.json` at load time.

**Tests**
- Non-elevated all-users tests are inconclusive when the runner is elevated on Windows.
- Added coverage for unreadable machine seed falling back to a writable AppData config.

### Behaviour matrix

| Scenario | Active writable config |
|---|---|
| Per-user install | `%AppData%\pyRevit\` |
| Admin install, standard user | `%AppData%\pyRevit\` (seeded from ProgramData if present) |
| Admin install, elevated CLI | `%ProgramData%\pyRevit\` |
| Admin-locked seed (`--lock`) | ProgramData read-only for all users |

## Related Issues

- Follow-up to #3504 / #3512 (admin install ProgramData config permissions)

## Additional Notes

- Regular per-user installer (`pyrevit.iss`) still runs `configs seedshippeddefaults` as the installing user into their AppData — unaffected.
- Elevated-only test cases remain inconclusive when not running elevated on Windows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8154a8f7-94ae-494c-a9e3-813d9a7ce78c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8154a8f7-94ae-494c-a9e3-813d9a7ce78c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

