### PR TITLE
fix: heal short malformed telemetry config empties

### DIFF
--- a/pyrevitlib/pyrevit/unittests/test_upgrade.py
+++ b/pyrevitlib/pyrevit/unittests/test_upgrade.py
@@ -61,9 +61,11 @@ def _load_upgrade_module():
         sys.modules['pyrevit.coreutils.logger'] = logger_module
 
         module_path = os.path.join(pyrevit_root, 'versionmgr', 'upgrade.py')
-        spec = importlib.util.spec_from_file_location(
+        if importlib_util is None:
+            raise unittest.SkipTest('importlib.util is required to load upgrade.py')
+        spec = importlib_util.spec_from_file_location(
             'pyrevit_upgrade_test', module_path)
-        module = importlib.util.module_from_spec(spec)
+        module = importlib_util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module
     finally:

--- a/pyrevitlib/pyrevit/unittests/test_upgrade.py
+++ b/pyrevitlib/pyrevit/unittests/test_upgrade.py
@@ -34,14 +34,21 @@ def _load_upgrade_module():
     previous = {name: sys.modules.get(name) for name in module_names}
 
     try:
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        pyrevit_root = os.path.join(repo_root, 'pyrevit')
+        coreutils_root = os.path.join(pyrevit_root, 'coreutils')
+
         appdata_module = types.ModuleType('pyrevit.coreutils.appdata')
         logger_module = types.ModuleType('pyrevit.coreutils.logger')
         logger_module.get_logger = lambda name: _DummyLogger()
 
         coreutils_module = types.ModuleType('pyrevit.coreutils')
+        coreutils_module.__path__ = [coreutils_root]
         coreutils_module.appdata = appdata_module
+        coreutils_module.logger = logger_module
 
         pyrevit_module = types.ModuleType('pyrevit')
+        pyrevit_module.__path__ = [pyrevit_root]
         pyrevit_module.coreutils = coreutils_module
 
         sys.modules['pyrevit'] = pyrevit_module
@@ -49,8 +56,7 @@ def _load_upgrade_module():
         sys.modules['pyrevit.coreutils.appdata'] = appdata_module
         sys.modules['pyrevit.coreutils.logger'] = logger_module
 
-        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        module_path = os.path.join(repo_root, 'pyrevit', 'versionmgr', 'upgrade.py')
+        module_path = os.path.join(pyrevit_root, 'versionmgr', 'upgrade.py')
         spec = importlib.util.spec_from_file_location(
             'pyrevit_upgrade_test', module_path)
         module = importlib.util.module_from_spec(spec)

--- a/pyrevitlib/pyrevit/unittests/test_upgrade.py
+++ b/pyrevitlib/pyrevit/unittests/test_upgrade.py
@@ -1,13 +1,17 @@
 """Tests for config upgrade helpers."""
 
 import glob
-import importlib.util
 import json
 import os
 import sys
 import tempfile
 import types
 import unittest
+
+try:
+    import importlib.util as importlib_util
+except ImportError:  # IronPython 2 / Python 2.7
+    importlib_util = None
 
 
 class _DummyLogger(object):

--- a/pyrevitlib/pyrevit/unittests/test_upgrade.py
+++ b/pyrevitlib/pyrevit/unittests/test_upgrade.py
@@ -1,0 +1,194 @@
+"""Tests for config upgrade helpers."""
+
+import glob
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+
+class _DummyLogger(object):
+    def debug(self, *args, **kwargs):
+        pass
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+def _load_upgrade_module():
+    module_names = (
+        'pyrevit',
+        'pyrevit.coreutils',
+        'pyrevit.coreutils.appdata',
+        'pyrevit.coreutils.logger',
+    )
+    previous = {name: sys.modules.get(name) for name in module_names}
+
+    try:
+        appdata_module = types.ModuleType('pyrevit.coreutils.appdata')
+        logger_module = types.ModuleType('pyrevit.coreutils.logger')
+        logger_module.get_logger = lambda name: _DummyLogger()
+
+        coreutils_module = types.ModuleType('pyrevit.coreutils')
+        coreutils_module.appdata = appdata_module
+
+        pyrevit_module = types.ModuleType('pyrevit')
+        pyrevit_module.coreutils = coreutils_module
+
+        sys.modules['pyrevit'] = pyrevit_module
+        sys.modules['pyrevit.coreutils'] = coreutils_module
+        sys.modules['pyrevit.coreutils.appdata'] = appdata_module
+        sys.modules['pyrevit.coreutils.logger'] = logger_module
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        module_path = os.path.join(repo_root, 'pyrevit', 'versionmgr', 'upgrade.py')
+        spec = importlib.util.spec_from_file_location(
+            'pyrevit_upgrade_test', module_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, original in previous.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+upgrade = _load_upgrade_module()
+
+
+class _FakeTelemetryParser(object):
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, section_name, field_name):
+        return self._values[field_name]
+
+
+class _FakeTelemetrySection(object):
+    def __init__(self, values):
+        self._values = values
+        self._parser = _FakeTelemetryParser(values)
+        self._section_name = 'telemetry'
+
+    def has_option(self, field_name):
+        return field_name in self._values
+
+    def __getattr__(self, field_name):
+        if field_name in self._values:
+            return self._values[field_name]
+        raise AttributeError(field_name)
+
+    def __setattr__(self, field_name, value):
+        if field_name in ('_values', '_parser', '_section_name'):
+            object.__setattr__(self, field_name, value)
+        else:
+            self._values[field_name] = value
+
+
+class _FakeUserConfig(object):
+    def __init__(self, values, config_file):
+        self.telemetry = _FakeTelemetrySection(values)
+        self.config_file = config_file
+
+    def has_section(self, section_name):
+        return section_name == 'telemetry'
+
+
+class HealBloatedTelemetryFieldsTests(unittest.TestCase):
+    def _make_config(self, values):
+        tempdir = tempfile.mkdtemp()
+        config_file = os.path.join(tempdir, 'pyrevit_config.ini')
+        with open(config_file, 'w') as cfg_file:
+            cfg_file.write('[telemetry]\n')
+        return _FakeUserConfig(values, config_file), tempdir
+
+    def test_heals_realistically_corrupted_empty_values(self):
+        values = {
+            'telemetry_file_dir': '"\\"\\"\\""',
+            'telemetry_server_url': '"\\"\\"\\"/"/"',
+            'apptelemetry_server_url': '"\\"\\"\\"/"/"',
+        }
+        user_config, tempdir = self._make_config(values)
+
+        healed = upgrade.heal_bloated_telemetry_fields(user_config)
+
+        self.assertEqual(sorted(values), sorted(healed))
+        self.assertEqual('', values['telemetry_file_dir'])
+        self.assertEqual('', values['telemetry_server_url'])
+        self.assertEqual('', values['apptelemetry_server_url'])
+        self.assertEqual(
+            1,
+            len(glob.glob(
+                os.path.join(tempdir, 'pyrevit_config.ini.bloated.*.bak'))),
+        )
+
+    def test_preserves_valid_below_threshold_values(self):
+        values = {
+            'telemetry_file_dir': json.dumps(
+                'C:\\logs', separators=(',', ':'), ensure_ascii=False),
+            'telemetry_server_url': json.dumps(
+                'https://telem.example.com',
+                separators=(',', ':'),
+                ensure_ascii=False),
+            'apptelemetry_server_url': json.dumps(
+                'https://apptelm.example.com',
+                separators=(',', ':'),
+                ensure_ascii=False),
+        }
+        user_config, tempdir = self._make_config(values)
+
+        healed = upgrade.heal_bloated_telemetry_fields(user_config)
+
+        self.assertEqual([], healed)
+        self.assertEqual(values['telemetry_file_dir'],
+                         json.dumps('C:\\logs',
+                                    separators=(',', ':'),
+                                    ensure_ascii=False))
+        self.assertEqual(
+            values['telemetry_server_url'],
+            json.dumps('https://telem.example.com',
+                       separators=(',', ':'),
+                       ensure_ascii=False))
+        self.assertEqual(
+            values['apptelemetry_server_url'],
+            json.dumps('https://apptelm.example.com',
+                       separators=(',', ':'),
+                       ensure_ascii=False))
+        self.assertEqual(
+            [],
+            glob.glob(
+                os.path.join(tempdir, 'pyrevit_config.ini.bloated.*.bak')),
+        )
+
+    def test_preserves_empty_values(self):
+        values = {
+            'telemetry_file_dir': '',
+            'telemetry_server_url': '""',
+            'apptelemetry_server_url': '',
+        }
+        user_config, _ = self._make_config(values)
+
+        healed = upgrade.heal_bloated_telemetry_fields(user_config)
+
+        self.assertEqual([], healed)
+
+    def test_heals_oversized_values_by_length(self):
+        oversized_value = 'x' * (upgrade.TELEMETRY_FIELD_MAX_LEN + 1)
+        values = {'telemetry_server_url': oversized_value}
+        user_config, _ = self._make_config(values)
+
+        healed = upgrade.heal_bloated_telemetry_fields(user_config)
+
+        self.assertEqual(['telemetry_server_url'], healed)
+        self.assertEqual('', values['telemetry_server_url'])

--- a/pyrevitlib/pyrevit/versionmgr/upgrade.py
+++ b/pyrevitlib/pyrevit/versionmgr/upgrade.py
@@ -17,6 +17,38 @@ TELEMETRY_BLOAT_FIELDS = (
     'telemetry_server_url',
     'apptelemetry_server_url',
 )
+TELEMETRY_URL_FIELDS = (
+    'telemetry_server_url',
+    'apptelemetry_server_url',
+)
+
+
+def _strip_telemetry_corruption_markers(field_name, value):
+    """Strip quote and escape artifacts left by the escape-doubling bug."""
+    if not value:
+        return ''
+
+    normalized = ''.join(value.split())
+    for marker in ('"', "'", '\\'):
+        normalized = normalized.replace(marker, '')
+    if field_name in TELEMETRY_URL_FIELDS:
+        normalized = normalized.replace('/', '')
+    return normalized
+
+
+def _is_bloated_telemetry_value(field_name, raw_value):
+    """Return True when a telemetry config value matches known corruption."""
+    if len(raw_value) > TELEMETRY_FIELD_MAX_LEN:
+        return True
+
+    compact_value = ''.join(raw_value.split())
+    if not compact_value or compact_value == '""':
+        return False
+
+    if '"' not in compact_value and "'" not in compact_value:
+        return False
+
+    return not _strip_telemetry_corruption_markers(field_name, compact_value)
 
 
 def heal_bloated_telemetry_fields(user_config):
@@ -43,7 +75,7 @@ def heal_bloated_telemetry_fields(user_config):
                 'Could not read telemetry field %r for bloat check | %s',
                 field_name, read_err)
             continue
-        if len(raw_value) > TELEMETRY_FIELD_MAX_LEN:
+        if _is_bloated_telemetry_value(field_name, raw_value):
             bloated.append((field_name, len(raw_value)))
 
     if not bloated:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`heal_bloated_telemetry_fields()` only reset telemetry config fields when they exceeded 8192 characters. After the escape-doubling fix in #3337, many users still have short frozen garbage values (~14–16 chars) that were never configured but read as nonsense paths/URLs.

This change detects corruption by shape: values that contain only quote, escape, and slash artifacts (for URL fields) are treated as bloated regardless of length. The existing length threshold remains for extreme bloat from the original bug.

On the next pyRevit startup, affected fields are reset to `""` with the same backup-and-log behavior as before.

## Checklist

- [x] Code follows the PEP 8 style guide.
- [x] Changes are tested and verified to work as expected.

## Related Issues

- Resolves #3534

## Additional Notes

Adds `pyrevitlib/pyrevit/unittests/test_upgrade.py` with isolated tests for the heal path (no Revit host required).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a18efec4-5c01-45cc-a46a-a1babe46225e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a18efec4-5c01-45cc-a46a-a1babe46225e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

