### PR TITLE
Add horizontal auto-fit for legend columns

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/legend_utils.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/legend_utils.py
@@ -188,8 +188,8 @@ def autofit_column_widths(doc, view, notes_by_column, base_offsets, min_gap=0.0)
         if abs(delta) < 1e-9:
             continue
         translation = DB.XYZ(delta, 0.0, 0.0)
-        for note in notes:
-            DB.ElementTransformUtils.MoveElement(doc, note.Id, translation)
+        ids = List[DB.ElementId]([note.Id for note in notes])
+        DB.ElementTransformUtils.MoveElements(doc, ids, translation)
 
     return new_offsets
 

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/legend_utils.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/legend_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Shared drawing helpers for the Filter Legend tool."""
+
 from pyrevit import DB
 from pyrevit.framework import List
 
@@ -113,6 +114,84 @@ def text_note_vertical_extent(note, view):
     top_y = max(bbox.Min.Y, bbox.Max.Y)
     bottom_y = min(bbox.Min.Y, bbox.Max.Y)
     return top_y, bottom_y, top_y - bottom_y
+
+
+def text_note_horizontal_extent(note, view):
+    """Measure a TextNote's actual, as-rendered horizontal footprint.
+
+    Mirrors text_note_vertical_extent, but for width. Character widths
+    depend on the TextNoteType's font/size, which varies per project,
+    so the real bounding box is measured rather than assumed.
+
+    Args:
+        note: a just-created TextNote (must belong to `view`)
+        view: the view the note was created in
+
+    Returns:
+        tuple: (left_x, right_x, width) in feet, or None if Revit can't
+            report a bounding box for this note/view.
+    """
+    bbox = note.get_BoundingBox(view)
+    if bbox is None:
+        return None
+    left_x = min(bbox.Min.X, bbox.Max.X)
+    right_x = max(bbox.Min.X, bbox.Max.X)
+    return left_x, right_x, right_x - left_x
+
+
+def autofit_column_widths(doc, view, notes_by_column, base_offsets, min_gap=0.0):
+    """Widen any column whose rendered text overflows its configured
+    width, shifting every column after it right to compensate.
+
+    Must be called after *every* row (header + data) has been created --
+    only then is the widest note in each column known. Moves notes in
+    place via ElementTransformUtils rather than deleting/recreating
+    them, so per-instance state (overrides etc.) is preserved.
+
+    Args:
+        doc: Document
+        view: the Legend view the notes live in
+        notes_by_column: list of lists of TextNote, one inner list per
+            column, left to right, e.g. [name_notes, param_notes,
+            value_notes]. Each inner list holds every note placed in
+            that column across all rows.
+        base_offsets: list of the X offsets (feet) each column was
+            originally created at -- same length/order as
+            notes_by_column.
+        min_gap: minimum horizontal gap (feet) to leave after the
+            widest note in a column before the next column starts.
+            Only applied when that column actually overflows its
+            configured width.
+
+    Returns:
+        list: the new X offsets actually applied, same length as
+            base_offsets (offsets[0] is always unchanged -- nothing to
+            the left of the first column to push into).
+    """
+    col_widths = []
+    for notes in notes_by_column:
+        widest = 0.0
+        for note in notes:
+            extent = text_note_horizontal_extent(note, view)
+            if extent is not None:
+                widest = max(widest, extent[2])
+        col_widths.append(widest)
+
+    new_offsets = [base_offsets[0]]
+    for i in range(len(base_offsets) - 1):
+        configured_width = base_offsets[i + 1] - base_offsets[i]
+        needed_width = max(configured_width, col_widths[i] + min_gap)
+        new_offsets.append(new_offsets[i] + needed_width)
+
+    for i, notes in enumerate(notes_by_column):
+        delta = new_offsets[i] - base_offsets[i]
+        if abs(delta) < 1e-9:
+            continue
+        translation = DB.XYZ(delta, 0.0, 0.0)
+        for note in notes:
+            DB.ElementTransformUtils.MoveElement(doc, note.Id, translation)
+
+    return new_offsets
 
 
 def create_legend_row(

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/script.py
@@ -31,6 +31,7 @@ from match.filter_utils import (
 from legend_utils import (
     create_legend_row,
     unique_view_name,
+    autofit_column_widths,
 )
 from legend_config import (
     INI,
@@ -115,7 +116,7 @@ if not text_type_names:
 # READ SETTINGS (configured separately via config.py -- see its
 # "Configure" bundle action; sensible defaults apply if never run)
 # ---------------------------------------------------------------------------
-CONFIG_FILE = appdata.get_universal_data_file(file_id=INI, file_ext='ini')
+CONFIG_FILE = appdata.get_universal_data_file(file_id=INI, file_ext="ini")
 if not op.exists(CONFIG_FILE):
     open(CONFIG_FILE, "w").close()
 configparser = PyRevitConfigParser(cfg_file_path=CONFIG_FILE)
@@ -189,6 +190,7 @@ with revit.TransactionGroup("Create Filter Legend(s)"):
                     filter_elems.sort(key=lambda f: f.Name)
 
                 y = 0.0
+                name_notes, param_notes, value_notes = [], [], []
 
                 # -- header row --
                 # Row height/next-row offset is measured from the actual
@@ -196,7 +198,7 @@ with revit.TransactionGroup("Create Filter Legend(s)"):
                 # not assumed equal to the configured row_height -- that's
                 # what keeps rows from overlapping/misaligning regardless
                 # of which TextNoteType/font size a given project uses.
-                _, _, header_height = create_legend_row(
+                header_notes, _, header_height = create_legend_row(
                     doc,
                     legend_view,
                     y,
@@ -208,6 +210,9 @@ with revit.TransactionGroup("Create Filter Legend(s)"):
                     ],
                     min_row_height=row_height,
                 )
+                name_notes.append(header_notes[0])
+                param_notes.append(header_notes[1])
+                value_notes.append(header_notes[2])
                 y -= header_height + row_spacing
 
                 # -- data rows --
@@ -229,7 +234,7 @@ with revit.TransactionGroup("Create Filter Legend(s)"):
                             param_name = NA_TEXT
                             value_text = NA_TEXT
 
-                        _, region, row_advance = create_legend_row(
+                        row_notes, region, row_advance = create_legend_row(
                             doc,
                             legend_view,
                             y,
@@ -243,6 +248,9 @@ with revit.TransactionGroup("Create Filter Legend(s)"):
                             swatch_height=row_height,
                             min_row_height=row_height,
                         )
+                        name_notes.append(row_notes[0])
+                        param_notes.append(row_notes[1])
+                        value_notes.append(row_notes[2])
                         if ogs and region and ogs_has_overrides(ogs):
                             legend_view.SetElementOverrides(region.Id, ogs)
 
@@ -255,6 +263,15 @@ with revit.TransactionGroup("Create Filter Legend(s)"):
                         row_advance = row_height
 
                     y -= row_advance + row_spacing
+
+                # -- auto-fit column widths to actual rendered text --
+                autofit_column_widths(
+                    doc,
+                    legend_view,
+                    notes_by_column=[name_notes, param_notes, value_notes],
+                    base_offsets=[COL_NAME_X, COL_PARAM_X, COL_VALUE_X],
+                    min_gap=col_width * 0.05,
+                )
 
                 created_legends.append(legend_view)
 


### PR DESCRIPTION
## Description

## Auto-fit column widths in Filter Legend rows

Mirrors the existing vertical auto-fit (row height from measured `TextNote` bounding boxes) but for the horizontal axis.

**Problem:** Column widths were fixed from config (`text_column_width`), so long filter names / parameter values / display values could overflow into the next column.

**Fix:**
- `text_note_horizontal_extent()` – measures a note's real left/right/width via its bounding box (mirrors `text_note_vertical_extent`).
- `autofit_column_widths()` – run once per legend view after all rows (header + data) are created, since column N's offset depends on column N-1's actual widest note. Computes per-column max width, expands any column that overflows its configured width (+`min_gap`), and translates the affected notes with `ElementTransformUtils.MoveElement` — no delete/recreate, so per-instance state is preserved.
- `script.py` now collects notes per column (`name_notes`, `param_notes`, `value_notes`) as rows are created, and calls `autofit_column_widths` right before appending the finished legend view.

Only widens columns, never shrinks below configured width. Swatch column excluded (fixed width, not text-driven).

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.


