### PR TITLE
fix(ci): keep current SHA when pruning ci-binaries assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         if: >
           github.repository == env.MainRepo &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         shell: pwsh
         working-directory: ${{ github.workspace }}
         env:
@@ -100,9 +100,14 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $branch = $env:BRANCH_NAME
           $sha = $env:COMMIT_SHA
-          $safeBranch = $branch -replace '[/\\]', '-'
+          # Tags are cut from master. Publish as master-latest so clone-of-master
+          # still works when the master push event never ran.
+          if ($env:GITHUB_REF -like 'refs/tags/v*') {
+            $safeBranch = 'master'
+          } else {
+            $safeBranch = $env:BRANCH_NAME -replace '[/\\]', '-'
+          }
           $shaZip = "unsigned-bin-$sha.zip"
           $branchZip = "unsigned-bin-$safeBranch-latest.zip"
           Compress-Archive -Path bin -DestinationPath $shaZip -Force
@@ -118,13 +123,17 @@ jobs:
         if: >
           github.repository == env.MainRepo &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           $ErrorActionPreference = 'Stop'
           $keep = New-Object System.Collections.Generic.HashSet[string]
+          # status=completed omits this in-progress run, so keep github.sha or the
+          # zip just uploaded is deleted as "not in the last 3 completed runs".
+          [void]$keep.Add($env:COMMIT_SHA)
           foreach ($branch in @('develop', 'master')) {
             $runs = gh api "repos/pyrevitlabs/pyRevit/actions/workflows/ci.yml/runs" `
               -f branch=$branch -f status=completed -f per_page=10 `
@@ -145,7 +154,7 @@ jobs:
         if: >
           github.repository == env.MainRepo &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         shell: pwsh
         working-directory: ${{ github.workspace }}
         env:
@@ -189,13 +198,17 @@ jobs:
         if: >
           github.repository == env.MainRepo &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+          (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           $ErrorActionPreference = 'Stop'
           $keep = New-Object System.Collections.Generic.HashSet[string]
+          # status=completed omits this in-progress run, so keep github.sha or the
+          # package just pushed is deleted as "not in the last 2 completed runs".
+          [void]$keep.Add($env:COMMIT_SHA)
           foreach ($branch in @('develop', 'master')) {
             $runs = gh api "repos/pyrevitlabs/pyRevit/actions/workflows/ci.yml/runs" `
               -f branch=$branch -f status=completed -f per_page=10 `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
           (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         shell: pwsh
+        working-directory: ${{ github.workspace }}
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ github.sha }}
@@ -140,6 +141,16 @@ jobs:
               --jq '.workflow_runs[] | select(.conclusion=="success") | .head_sha'
             $runs | Select-Object -First 3 | ForEach-Object { [void]$keep.Add($_) }
           }
+          # Tag CI reports head_branch as the tag name, so those runs never appear
+          # in the develop/master queries. Keep recent v* tag SHAs so a tagged
+          # release's per-commit zip survives the next develop prune when master
+          # CI never ran.
+          git tag -l "v*" --sort=-creatordate |
+            Select-Object -First 3 |
+            ForEach-Object {
+              $tagSha = git rev-list -n 1 $_
+              if ($tagSha) { [void]$keep.Add($tagSha.Trim()) }
+            }
           $assets = gh release view ci-binaries --json assets --jq '.assets[].name'
           foreach ($asset in $assets) {
             if ($asset -match '^unsigned-bin-.+-latest\.zip$') { continue }
@@ -200,6 +211,7 @@ jobs:
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
           (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         shell: pwsh
+        working-directory: ${{ github.workspace }}
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ github.sha }}
@@ -215,6 +227,13 @@ jobs:
               --jq '.workflow_runs[] | select(.conclusion=="success") | .head_sha'
             $runs | Select-Object -First 2 | ForEach-Object { [void]$keep.Add($_) }
           }
+          # Same as release-asset prune: tag runs are invisible to branch= queries.
+          git tag -l "v*" --sort=-creatordate |
+            Select-Object -First 2 |
+            ForEach-Object {
+              $tagSha = git rev-list -n 1 $_
+              if ($tagSha) { [void]$keep.Add($tagSha.Trim()) }
+            }
           $versions = gh api --paginate "orgs/pyrevitlabs/packages/nuget/pyrevit.unsignedbin/versions" | ConvertFrom-Json
           foreach ($version in $versions) {
             if ($version.name -notmatch '^1\.0\.0-ci-([a-f0-9]{7})$') { continue }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,27 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: bin/
 
+      # Clone-of-master must not depend on the master push event (it can be dropped).
+      - name: Refresh ci-binaries master assets
+        shell: pwsh
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $sha = $env:COMMIT_SHA
+          $shaZip = "unsigned-bin-$sha.zip"
+          $branchZip = "unsigned-bin-master-latest.zip"
+          Compress-Archive -Path bin -DestinationPath $shaZip -Force
+          Copy-Item $shaZip $branchZip -Force
+          gh release view ci-binaries 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            gh release create ci-binaries --prerelease --title "CI Binaries" --notes "Pre-built bin/ from CI (anonymous download for pyrevit clone)."
+          }
+          gh release upload ci-binaries $shaZip --clobber
+          gh release upload ci-binaries $branchZip --clobber
+
       - name: Download stamped release metadata
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,9 @@ jobs:
           path: bin/
 
       # Clone-of-master must not depend on the master push event (it can be dropped).
+      # Best-effort: tag CI already uploaded these zips; do not block pack/sign/publish.
       - name: Refresh ci-binaries master assets
+        continue-on-error: true
         shell: pwsh
         working-directory: ${{ github.workspace }}
         env:

--- a/build/README.md
+++ b/build/README.md
@@ -99,7 +99,7 @@ pyrevit attach dev default --installed
 pyrevit clones update dev --skip-bin
 ```
 
-CI publishes `unsigned-bin-<sha>.zip` to the **`ci-binaries`** release and mirrors **`PyRevit.UnsignedBin`** on GitHub Packages (CLI fallback when `GITHUBTOKEN` is set). Release assets are pruned to the last **3 SHAs per branch** (`develop`, `master`), including the SHA of the run that is still in progress; NuGet package versions are pruned to the last **2 SHAs per branch**. Tag CI and `release.yml` also refresh **`unsigned-bin-master-latest.zip`**. See [CI/CD](../docs/ci-cd.md#prebuilt-binaries-for-clone).
+CI publishes `unsigned-bin-<sha>.zip` to the **`ci-binaries`** release and mirrors **`PyRevit.UnsignedBin`** on GitHub Packages (CLI fallback when `GITHUBTOKEN` is set). Release assets are pruned to the last **3 SHAs per branch** (`develop`, `master`), including the SHA of the run that is still in progress and the last **3 `v*` tag SHAs**; NuGet package versions are pruned to the last **2 SHAs per branch** plus the last 2 `v*` tag SHAs. Tag CI and `release.yml` also refresh **`unsigned-bin-master-latest.zip`**. See [CI/CD](../docs/ci-cd.md#prebuilt-binaries-for-clone).
 
 Run unit tests:
 

--- a/build/README.md
+++ b/build/README.md
@@ -99,7 +99,7 @@ pyrevit attach dev default --installed
 pyrevit clones update dev --skip-bin
 ```
 
-CI publishes `unsigned-bin-<sha>.zip` to the **`ci-binaries`** release and mirrors **`PyRevit.UnsignedBin`** on GitHub Packages (CLI fallback when `GITHUBTOKEN` is set). Release assets are pruned to the last **3 SHAs per branch** (`develop`, `master`); NuGet package versions are pruned to the last **2 SHAs per branch**. See [CI/CD](../docs/ci-cd.md#prebuilt-binaries-for-clone).
+CI publishes `unsigned-bin-<sha>.zip` to the **`ci-binaries`** release and mirrors **`PyRevit.UnsignedBin`** on GitHub Packages (CLI fallback when `GITHUBTOKEN` is set). Release assets are pruned to the last **3 SHAs per branch** (`develop`, `master`), including the SHA of the run that is still in progress; NuGet package versions are pruned to the last **2 SHAs per branch**. Tag CI and `release.yml` also refresh **`unsigned-bin-master-latest.zip`**. See [CI/CD](../docs/ci-cd.md#prebuilt-binaries-for-clone).
 
 Run unit tests:
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -19,9 +19,9 @@ pyRevit's pipeline is split across workflows in [`.github/workflows/`](https://g
 
 | Workflow | File | What it does |
 |----------|------|--------------|
-| **`pyRevit CI`** | [`ci.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/ci.yml) | Runs `dotnet run -- ci` to build unsigned DLLs, runs `dotnet test` on the build project, uploads `unsigned-bin-<sha>` (Actions artifact for WIP/release), and publishes the same zip to the public **`ci-binaries`** GitHub Release (for `pyrevit clone`). Runs on every push to `develop` / `master` / `v*` tag (with a path filter), on PRs to those branches, and on manual dispatch. |
+| **`pyRevit CI`** | [`ci.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/ci.yml) | Runs `dotnet run -- ci` to build unsigned DLLs, runs `dotnet test` on the build project, uploads `unsigned-bin-<sha>` (Actions artifact for WIP/release), and publishes the same zip to the public **`ci-binaries`** GitHub Release (for `pyrevit clone`). Runs on every push to `develop` / `master` / `v*` tag (with a path filter), on PRs to those branches, and on manual dispatch. Tag pushes also refresh `unsigned-bin-master-latest.zip`. |
 | **`pyRevit WIP`** | [`wip.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/wip.yml) | Downloads CI artifacts, runs `dotnet run -- pack sign` under the **`production`** environment, and uploads signed WIP installers. |
-| **`pyRevit Release`** | [`release.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/release.yml) | On `v*` tag pushes, waits for CI, runs `dotnet run -- release pack sign publish` under **`production`**, then notifies linked issues. |
+| **`pyRevit Release`** | [`release.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/release.yml) | On `v*` tag pushes, waits for CI, refreshes **`ci-binaries`** `unsigned-bin-master-latest.zip` from the unsigned CI payload, runs `dotnet run -- release pack sign publish` under **`production`**, then notifies linked issues. |
 | **`Update Winget manifests`** | [`winget.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/winget.yml) | After a GitHub release is **published**, runs `dotnet run -- winget` to submit WinGet manifest PRs. Strips `ElevationRequirement: elevationProhibited` from generated user-scope installers before submit (see Troubleshooting). |
 
 The CI **`notify`** job (develop pushes only) runs `dotnet run -- notify` inline in `ci.yml` with `issues: write` and does **not** use the `production` environment.
@@ -68,13 +68,15 @@ End users and contributors who only need to **run** pyRevit (not build C#) get `
 | `pyrevit clone` / `clones update` (token fallback) | Actions artifact `unsigned-bin-<sha>` | `GITHUBTOKEN` (`actions:read`) |
 | WIP / release pack pipelines | Actions artifact `unsigned-bin-<sha>` | `GITHUB_TOKEN` in CI |
 
-After each successful CI push to **`develop`** or **`master`** on the main repo:
+After each successful CI push to **`develop`** or **`master`** on the main repo (and after each **`v*`** tag CI run):
 
 1. CI zips `bin/` → `unsigned-bin-{fullSha}.zip`
-2. Uploads to Release tag **`ci-binaries`** (pre-release), plus rolling **`unsigned-bin-{branch}-latest.zip`**
+2. Uploads to Release tag **`ci-binaries`** (pre-release), plus rolling **`unsigned-bin-{branch}-latest.zip`**. Tag runs publish as **`unsigned-bin-master-latest.zip`** so clone-of-master does not depend on the master push event.
 3. Pushes **`PyRevit.UnsignedBin`** NuGet package to GitHub Packages (token-authenticated CLI mirror)
-4. Prunes per-SHA release assets older than the **last 3 successful CI builds** per branch (`develop`, `master`); branch-latest zips are always kept
-5. Prunes **`PyRevit.UnsignedBin`** NuGet versions older than the **last 2 successful CI builds** per branch (`develop`, `master`)
+4. Prunes per-SHA release assets older than the **last 3 successful CI builds** per branch (`develop`, `master`), **including the in-progress run's SHA** (the Actions API `status=completed` filter would otherwise omit it and the just-uploaded zip would be deleted). Branch-latest zips are always kept.
+5. Prunes **`PyRevit.UnsignedBin`** NuGet versions older than the **last 2 successful CI builds** per branch (`develop`, `master`), also keeping the in-progress run's SHA.
+
+`release.yml` then re-uploads the same unsigned payload as `unsigned-bin-{sha}.zip` and `unsigned-bin-master-latest.zip` after it downloads the CI artifact — a second path so a dropped master push cannot leave clone-of-master on a previous release's binaries.
 
 Anonymous download URL pattern:
 
@@ -151,8 +153,8 @@ Releases are no longer auto-triggered by merging into `master`. A maintainer run
 
 4. Pushing the tag triggers two workflows in parallel:
 
-    - **`ci.yml`** rebuilds DLLs on the tagged commit and uploads `unsigned-bin-<sha>` (DLLs only; installers are no longer built in CI).
-    - **`release.yml`** starts immediately and polls for the matching CI run (via `gh run watch`). The **`release`** job downloads CI artifacts, runs `dotnet run -- release pack sign publish` under **`production`** (sign via `sign code trusted-signing`, draft GitHub Release, Chocolatey push). **`notify`** then posts to linked issues. After you publish the draft release, **`winget.yml`** submits WinGet manifest PRs.
+    - **`ci.yml`** rebuilds DLLs on the tagged commit and uploads `unsigned-bin-<sha>` (DLLs only; installers are no longer built in CI). Tag CI also publishes that zip to **`ci-binaries`** as `unsigned-bin-master-latest.zip`.
+    - **`release.yml`** starts immediately and polls for the matching CI run (via `gh run watch`). The **`release`** job downloads CI artifacts, refreshes **`ci-binaries`** `unsigned-bin-master-latest.zip` from the unsigned payload, then runs `dotnet run -- release pack sign publish` under **`production`** (sign via `sign code trusted-signing`, draft GitHub Release, Chocolatey push). **`notify`** then posts to linked issues. After you publish the draft release, **`winget.yml`** submits WinGet manifest PRs.
 
 5. Open the draft release on GitHub, review the auto-generated notes, then publish it.
 
@@ -239,6 +241,7 @@ CI invokes the ModularPipelines project from [`build/`](../build/) via `dotnet r
 - **Release fails on `Validate tag matches version`**: the tag (e.g. `v4.8.16`) doesn't match `pyrevitlib/pyrevit/version`. Delete and recreate the tag with the right name, or update the version file and re-tag. If the tag and checkout match but the error shows different `+HHMM` suffixes (e.g. tag `+1406` vs file `+1212`), CI re-stamped the build number on a tag push — tag CI must preserve the committed version; move the tag to a commit that includes that fix and re-run.
 - **Release fails on `Wait for CI to complete on tagged commit`**: CI either failed or didn't start within 10 minutes of the tag push. Investigate the CI run for the tagged SHA; once it is green, re-run `release.yml`.
 - **Release fails on `Download unsigned bin artifact`**: the CI run exists but the expected `unsigned-bin-<sha>` artifact is missing (most often because CI failed before the upload step). Fix CI and re-run `release.yml`.
+- **`unsigned-bin-master-latest.zip` is older than the current `master` HEAD / tagged release**: the master push event may have been dropped, or prune previously deleted the per-SHA zip. Run **`workflow_dispatch`** of `ci.yml` on **`master`** to rebuild and refresh `ci-binaries`. Tag CI and `release.yml` also refresh `unsigned-bin-master-latest.zip` so clone-of-master does not depend on that push.
 - **Release fails on `Build Installers`**: Inno Setup (`ISCC.exe`), MSBuild, or the legacy WiX v3.x CLI MSI project failed. `windows-2025` preinstalls Inno Setup 6 and WiX Toolset v3.x; MSBuild is resolved from `PATH` or Visual Studio's `vswhere.exe`. Local installer builds need the same tools installed.
 - **Release fails on `Build Choco Package`**: `choco pack` failed, or the upstream signed installer was missing when the SHA was computed. Confirm `Sign installers` produced the expected `dist/*.exe`/`.msi` outputs before this step ran.
 - **Release fails on `Sign Choco Package`**: this step uses the `dotnet sign` CLI (installed via `dotnet tool install --global sign --prerelease`) and authenticates to Azure Trusted Signing via the `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` env vars (DefaultAzureCredential chain). Common causes: (a) the certificate profile lacks the `1.3.6.1.5.5.7.3.3` Code Signing EKU required for NuGet author signing; (b) the App Registration is missing the `Trusted Signing Certificate Profile Signer` role on the Signing Account; (c) the `--prerelease` flag was removed and `sign` is no longer marked prerelease (drop `--prerelease` once the tool has a stable GA release). The previous attempt used `Azure/artifact-signing-action`, but its v2.0.0 PowerShell module routes `.nupkg` to `signtool.exe`, which doesn't recognize the format. Don't switch back without verifying upstream support for NuGet via that action.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -73,10 +73,10 @@ After each successful CI push to **`develop`** or **`master`** on the main repo 
 1. CI zips `bin/` → `unsigned-bin-{fullSha}.zip`
 2. Uploads to Release tag **`ci-binaries`** (pre-release), plus rolling **`unsigned-bin-{branch}-latest.zip`**. Tag runs publish as **`unsigned-bin-master-latest.zip`** so clone-of-master does not depend on the master push event.
 3. Pushes **`PyRevit.UnsignedBin`** NuGet package to GitHub Packages (token-authenticated CLI mirror)
-4. Prunes per-SHA release assets older than the **last 3 successful CI builds** per branch (`develop`, `master`), **including the in-progress run's SHA** (the Actions API `status=completed` filter would otherwise omit it and the just-uploaded zip would be deleted). Branch-latest zips are always kept.
-5. Prunes **`PyRevit.UnsignedBin`** NuGet versions older than the **last 2 successful CI builds** per branch (`develop`, `master`), also keeping the in-progress run's SHA.
+4. Prunes per-SHA release assets older than the **last 3 successful CI builds** per branch (`develop`, `master`), **including the in-progress run's SHA** (the Actions API `status=completed` filter would otherwise omit it and the just-uploaded zip would be deleted) **and the SHAs of the last 3 `v*` tags** (tag CI reports `head_branch` as the tag name, so those runs never appear in the `branch=develop` / `branch=master` queries). Branch-latest zips are always kept.
+5. Prunes **`PyRevit.UnsignedBin`** NuGet versions older than the **last 2 successful CI builds** per branch (`develop`, `master`), also keeping the in-progress run's SHA and the last 2 `v*` tag SHAs.
 
-`release.yml` then re-uploads the same unsigned payload as `unsigned-bin-{sha}.zip` and `unsigned-bin-master-latest.zip` after it downloads the CI artifact — a second path so a dropped master push cannot leave clone-of-master on a previous release's binaries.
+`release.yml` then re-uploads the same unsigned payload as `unsigned-bin-{sha}.zip` and `unsigned-bin-master-latest.zip` after it downloads the CI artifact — a second, **best-effort** path so a dropped master push cannot leave clone-of-master on a previous release's binaries. A failure there does not block pack/sign/publish.
 
 Anonymous download URL pattern:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes two related `ci-binaries` publish/prune defects from #3555, found when a fresh 6.5.3 clone received 6.5.2-stamped binaries.

**A. Per-SHA assets were deleted by the run that uploaded them.** The prune keep-list was built from `status=completed` workflow runs, which excludes the in-progress job. Every push uploaded `unsigned-bin-<sha>.zip` and then deleted it as "not in the last 3 completed runs". The `ci-binaries` release therefore held only the two `-latest` zips, and the CLI's documented per-commit download path could never hit.

Both prune steps (release assets and the NuGet mirror) now add `github.sha` to the keep set before querying completed runs. They also keep the SHAs of recent `v*` tags: tag CI reports `head_branch` as the tag name, so those runs never appear in the `branch=develop` / `branch=master` queries. Without that, a tagged release's per-commit zip would be deleted by the next develop prune whenever master CI never ran for that SHA.

**B. `unsigned-bin-master-latest.zip` went stale when the master push event was dropped.** Tag CI already built the correct payload, but the publish `if:` excluded `refs/tags/*`. This change:

- Publishes tag CI as `unsigned-bin-<sha>.zip` + `unsigned-bin-master-latest.zip` (tags are cut from master).
- Has `release.yml` re-upload the same unsigned payload after it downloads the CI artifact (`continue-on-error: true` so a transient upload hiccup cannot block pack/sign/publish).

### Immediate heal (maintainer)

This PR does not refresh the currently stale 6.5.2 `unsigned-bin-master-latest.zip`. After merge, or independently of it (branch-latest assets are never pruned), run **workflow_dispatch** of `ci.yml` on **`master`** so clone-of-master picks up 6.5.3-stamped binaries.

---

## Checklist

- [x] Changes are tested and verified to work as expected. (YAML parses; prune/publish logic reviewed against the Actions run-status API. End-to-end confirmation needs a `develop`/`master`/tag CI run on the main repo.)
- [ ] Code follows the PEP 8 style guide. (N/A — workflow/docs only)
- [ ] Code has been formatted with Black. (N/A)

---

## Related Issues

- Resolves #3555

---

## Additional Notes

Follow-up from DevloAI review: keep recent `v*` tag SHAs in both prune keep-sets, and mark the `release.yml` heal as best-effort. Copilot reviewed the original diff and had no comments.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51a38bfb-172f-4687-9a53-e7c35f4bd938?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51a38bfb-172f-4687-9a53-e7c35f4bd938&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

