### PR TITLE
Restore `pyrevit clone --branch=v*` for published releases

### DIFF
--- a/build/Helpers/CloneBinPayloadHelper.cs
+++ b/build/Helpers/CloneBinPayloadHelper.cs
@@ -1,0 +1,28 @@
+using System.IO.Compression;
+
+namespace Build.Helpers;
+
+public static class CloneBinPayloadHelper
+{
+    public static string CreateSignedBinZip(string binPath, string destDirectory, string buildVersion)
+    {
+        if (!Directory.Exists(binPath))
+        {
+            throw new DirectoryNotFoundException($"Signed bin payload is missing at {binPath}.");
+        }
+
+        Directory.CreateDirectory(destDirectory);
+        var zipPath = Path.Combine(destDirectory, VersionHelper.GetCloneBinAssetName(buildVersion));
+        if (File.Exists(zipPath))
+        {
+            File.Delete(zipPath);
+        }
+
+        ZipFile.CreateFromDirectory(
+            binPath,
+            zipPath,
+            CompressionLevel.Fastest,
+            includeBaseDirectory: true);
+        return zipPath;
+    }
+}

--- a/build/Helpers/VersionHelper.cs
+++ b/build/Helpers/VersionHelper.cs
@@ -147,4 +147,9 @@ public static partial class VersionHelper
     {
         return $"https://github.com/pyrevitlabs/pyRevit/releases/tag/v{buildVersionUrlSafe}/";
     }
+
+    public static string GetCloneBinAssetName(string buildVersion)
+    {
+        return $"bin-v{buildVersion}.zip";
+    }
 }

--- a/build/Modules/PublishGithubReleaseModule.cs
+++ b/build/Modules/PublishGithubReleaseModule.cs
@@ -15,6 +15,7 @@ namespace Build.Modules;
 [SkipIfNoGitHubToken]
 [DependsOn<GenerateReleaseNotesModule>]
 [DependsOn<SignChocoPackageModule>]
+[DependsOn<SignBinariesModule>(Optional = true)]
 public sealed class PublishGithubReleaseModule(IOptions<PublishOptions> publishOptions) : Module<string>
 {
     protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -37,14 +38,19 @@ public sealed class PublishGithubReleaseModule(IOptions<PublishOptions> publishO
             repositoryInfo.RepositoryName,
             newRelease);
 
-        var assetFiles = Directory.Exists(PyRevitPaths.DistPath)
-            ? Directory.GetFiles(PyRevitPaths.DistPath)
-                .Where(file =>
-                    file.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
-                    || file.EndsWith(".msi", StringComparison.OrdinalIgnoreCase)
-                    || file.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
-                .ToArray()
-            : [];
+        Directory.CreateDirectory(PyRevitPaths.DistPath);
+        var cloneBinZip = CloneBinPayloadHelper.CreateSignedBinZip(
+            PyRevitPaths.BinPath,
+            PyRevitPaths.DistPath,
+            versionInfo.BuildVersion);
+
+        var assetFiles = Directory.GetFiles(PyRevitPaths.DistPath)
+            .Where(file =>
+                file.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                || file.EndsWith(".msi", StringComparison.OrdinalIgnoreCase)
+                || file.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(file, cloneBinZip, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
 
         await assetFiles
             .ForEachAsync(async filePath =>
@@ -61,7 +67,6 @@ public sealed class PublishGithubReleaseModule(IOptions<PublishOptions> publishO
             }, cancellationToken)
             .ProcessInParallel();
 
-        Directory.CreateDirectory(PyRevitPaths.DistPath);
         await File.WriteAllTextAsync(
             PyRevitPaths.GitHubReleaseUrlFile,
             release.HtmlUrl,

--- a/build/README.md
+++ b/build/README.md
@@ -71,7 +71,7 @@ On a **clean checkout** (no tracked `bin/`), `ci` builds in this order:
 
 This mirrors the legacy `pipenv run pyrevit build deps` + `build engines` + `build runtime` sequence.
 
-The `bin/` directory is **not tracked in git**. It is produced locally by `dotnet run -- ci` or downloaded by `pyrevit clone` / `pyrevit clones update` from **public GitHub Release assets** on the `ci-binaries` tag (`unsigned-bin-{sha}.zip`). Only **`develop`** and **`master`** are supported for CI binary download. Static assets are staged from [`release/bin-assets/`](../release/bin-assets/) and [`release/cengines/`](../release/cengines/); host/product JSON templates live under [`release/`](../release/). **Contributors edit** [`release/pyrevit-hosts.json`](../release/pyrevit-hosts.json), not files under `bin/`.
+The `bin/` directory is **not tracked in git**. It is produced locally by `dotnet run -- ci` or downloaded by `pyrevit clone` / `pyrevit clones update` from **public GitHub Release assets**: `ci-binaries` (`unsigned-bin-{sha}.zip`) for **`develop`** / **`master`**, and `bin-v{version}.zip` on published **`v*`** tags. Static assets are staged from [`release/bin-assets/`](../release/bin-assets/) and [`release/cengines/`](../release/cengines/); host/product JSON templates live under [`release/`](../release/). **Contributors edit** [`release/pyrevit-hosts.json`](../release/pyrevit-hosts.json), not files under `bin/`.
 
 ### Clone workflows (getting `bin/`)
 
@@ -99,7 +99,7 @@ pyrevit attach dev default --installed
 pyrevit clones update dev --skip-bin
 ```
 
-CI publishes `unsigned-bin-<sha>.zip` to the **`ci-binaries`** release and mirrors **`PyRevit.UnsignedBin`** on GitHub Packages (CLI fallback when `GITHUBTOKEN` is set). Release assets are pruned to the last **3 SHAs per branch** (`develop`, `master`); NuGet package versions are pruned to the last **2 SHAs per branch**. See [CI/CD](../docs/ci-cd.md#prebuilt-binaries-for-clone).
+CI publishes `unsigned-bin-<sha>.zip` to the **`ci-binaries`** release and mirrors **`PyRevit.UnsignedBin`** on GitHub Packages (CLI fallback when `GITHUBTOKEN` is set). Release assets are pruned to the last **3 SHAs per branch** (`develop`, `master`); NuGet package versions are pruned to the last **2 SHAs per branch**. Published `v*` GitHub Releases also attach signed `bin-v{version}.zip` for tag clones. See [CI/CD](../docs/ci-cd.md#prebuilt-binaries-for-clone).
 
 Run unit tests:
 

--- a/build/tests/CloneBinPayloadHelperTests.cs
+++ b/build/tests/CloneBinPayloadHelperTests.cs
@@ -1,0 +1,40 @@
+using System.IO.Compression;
+using Build.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Build.Tests;
+
+[TestClass]
+public sealed class CloneBinPayloadHelperTests
+{
+    [TestMethod]
+    public void CreateSignedBinZip_wrapsBinDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "pyrevit-clone-bin-" + Guid.NewGuid().ToString("N"));
+        var binPath = Path.Combine(root, "bin");
+        var distPath = Path.Combine(root, "dist");
+        Directory.CreateDirectory(Path.Combine(binPath, "netfx"));
+        File.WriteAllText(Path.Combine(binPath, "netfx", "marker.txt"), "ok");
+
+        try
+        {
+            var zipPath = CloneBinPayloadHelper.CreateSignedBinZip(binPath, distPath, "6.5.3.26176+2017");
+
+            Assert.AreEqual(Path.Combine(distPath, "bin-v6.5.3.26176+2017.zip"), zipPath);
+            Assert.IsTrue(File.Exists(zipPath));
+
+            using (var archive = ZipFile.OpenRead(zipPath))
+            {
+                Assert.IsTrue(archive.Entries.Any(entry =>
+                    entry.FullName.Replace('\\', '/').EndsWith("bin/netfx/marker.txt", StringComparison.Ordinal)));
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/build/tests/VersionHelperTests.cs
+++ b/build/tests/VersionHelperTests.cs
@@ -94,4 +94,10 @@ public sealed class VersionHelperTests
             Environment.SetEnvironmentVariable("GITHUB_REF", originalRef);
         }
     }
+
+    [TestMethod]
+    public void GetCloneBinAssetName_includesVersionTag()
+    {
+        Assert.AreEqual("bin-v6.5.3.26176+2017.zip", VersionHelper.GetCloneBinAssetName("6.5.3.26176+2017"));
+    }
 }

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLI.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLI.cs
@@ -222,7 +222,8 @@ namespace pyRevitCLI
                         repoUrl: TryGetValue("--source"),
                         imagePath: TryGetValue("--image"),
                         destPath: TryGetValue("--dest"),
-                        credentials: TryGetCredentials()
+                        credentials: TryGetCredentials(),
+                        skipBin: arguments["--skip-bin"].IsTrue
                     );
             }
 

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIAppHelps.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLIAppHelps.cs
@@ -85,7 +85,8 @@ namespace pyRevitCLI
                             { "--source=<image_url>",   "Clone source image url or path" },
                             { "--source=<repo_url>",    "Clone source git repo url" },
                             { "--image=<image_path>",   "Clone from a custom image (.zip archive)" },
-                            { "--branch=<branch_name>", "Branch to clone from" },
+                            { "--branch=<branch_name>", "Branch or release tag to clone from" },
+                            { "--skip-bin",             "Skip downloading pre-built binaries" },
                         });
                     break;
 

--- a/dev/pyRevitLabs/pyRevitCLI/PyRevitCLICloneCmds.cs
+++ b/dev/pyRevitLabs/pyRevitCLI/PyRevitCLICloneCmds.cs
@@ -48,7 +48,7 @@ namespace pyRevitCLI {
         }
 
         internal static void
-        CreateClone(string cloneName, string deployName, string branchName, string repoUrl, string imagePath, string destPath, GitInstallerCredentials credentials) {
+        CreateClone(string cloneName, string deployName, string branchName, string repoUrl, string imagePath, string destPath, GitInstallerCredentials credentials, bool skipBin = false) {
             // FIXME: implement image
             if (cloneName != null) {
                 // if deployment requested or image path is provided
@@ -58,7 +58,8 @@ namespace pyRevitCLI {
                         deploymentName: deployName,
                         branchName: branchName,
                         imagePath: imagePath,
-                        destPath: destPath
+                        destPath: destPath,
+                        installBinaries: !skipBin
                         );
                 // otherwise clone the full repo
                 else
@@ -68,7 +69,8 @@ namespace pyRevitCLI {
                         branchName: branchName,
                         repoUrl: repoUrl,
                         destPath: destPath,
-                        credentials: credentials
+                        credentials: credentials,
+                        installBinaries: !skipBin
                         );
             }
         }

--- a/dev/pyRevitLabs/pyRevitCLI/Resources/UsagePatterns.txt
+++ b/dev/pyRevitLabs/pyRevitCLI/Resources/UsagePatterns.txt
@@ -6,9 +6,9 @@ Usage:
 	pyrevit env [--json] [(-h | --help)] [--log=<log_file>]
 	pyrevit update [--help] [--log=<log_file>]
 	pyrevit clone (-h | --help)
-	pyrevit clone <clone_name> <deployment_name> [--dest=<dest_path>] [--branch=<branch_name>] [--log=<log_file>]
-	pyrevit clone <clone_name> --image=<image_url> [--dest=<dest_path>] [--log=<log_file>]
-	pyrevit clone <clone_name> [--dest=<dest_path>] [--source=<repo_url>] [--branch=<branch_name>] [--log=<log_file>] [(--username=<username> --password=<password> | --token=<auth_token>)]
+	pyrevit clone <clone_name> <deployment_name> [--dest=<dest_path>] [--branch=<branch_name>] [--skip-bin] [--log=<log_file>]
+	pyrevit clone <clone_name> --image=<image_url> [--dest=<dest_path>] [--skip-bin] [--log=<log_file>]
+	pyrevit clone <clone_name> [--dest=<dest_path>] [--source=<repo_url>] [--branch=<branch_name>] [--skip-bin] [--log=<log_file>] [(--username=<username> --password=<password> | --token=<auth_token>)]
 	pyrevit clones [(-h | --help)]
 	pyrevit clones (info | open) <clone_name>
 	pyrevit clones add this <clone_name> [--force] [--log=<log_file>]

--- a/dev/pyRevitLabs/pyRevitLabs.Common/BinArtifactInstaller.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/BinArtifactInstaller.cs
@@ -137,8 +137,7 @@ namespace pyRevitLabs.Common {
             }
 
             // Published v* releases attach a durable signed bin zip; try it when SHA assets are absent.
-            if (!BinArtifactSupport.IsSupportedCiBinBranch(branchName)
-                && !string.IsNullOrWhiteSpace(branchName)
+            if (BinArtifactSupport.IsVersionTagRef(branchName)
                 && TryDownloadVersionTagBin(repoId, branchName, destPath)) {
                 return true;
             }

--- a/dev/pyRevitLabs/pyRevitLabs.Common/BinArtifactInstaller.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/BinArtifactInstaller.cs
@@ -23,15 +23,6 @@ namespace pyRevitLabs.Common {
             if (string.IsNullOrWhiteSpace(clonePath))
                 throw new PyRevitException("Clone path can not be null.");
 
-            if (!BinArtifactSupport.IsSupportedCiBinBranch(branchName)) {
-                throw new pyRevitBinArtifactNotFoundException(
-                    string.Format(
-                        "CI binaries are only published for branches \"{0}\" and \"{1}\". "
-                        + "Checkout a supported branch or build locally with \"dotnet run -- ci\".",
-                        PyRevitLabsConsts.SupportedCiBinBranches[0],
-                        PyRevitLabsConsts.SupportedCiBinBranches[1]));
-            }
-
             if (mode == BinArtifactInstallMode.Update
                 && GitInstaller.IsValidRepo(clonePath)
                 && GitInstaller.IsLocalAheadOfTrackingBranch(clonePath)) {
@@ -80,8 +71,9 @@ namespace pyRevitLabs.Common {
                 if (!downloaded) {
                     throw new pyRevitBinArtifactNotFoundException(
                         string.Format(
-                            "Could not find pre-built binaries for commit \"{0}\" on branch \"{1}\". "
-                            + "Push the commit and wait for CI, or run \"dotnet run -- ci\" in the clone root.",
+                            "Could not find pre-built binaries for commit \"{0}\" on ref \"{1}\". "
+                            + "Wait for CI on develop/master, clone a published v* GitHub Release, "
+                            + "or run \"dotnet run -- ci\" in the clone root.",
                             normalizedSha,
                             branchName));
                 }
@@ -98,13 +90,19 @@ namespace pyRevitLabs.Common {
             }
         }
 
-        public static void InstallForRepoClone(string clonePath, string repoUrl, BinArtifactInstallMode mode) {
+        public static void InstallForRepoClone(
+            string clonePath,
+            string repoUrl,
+            BinArtifactInstallMode mode,
+            string branchName = null) {
             var repoId = GithubRepoHelper.ParseRepoId(repoUrl ?? GitInstaller.GetRemoteUrl(
                 clonePath,
                 PyRevitLabsConsts.DefaultRemoteName));
-            var branchName = GitInstaller.GetCheckedoutBranch(clonePath) ?? PyRevitLabsConsts.TargetBranch;
+            var resolvedBranch = !string.IsNullOrWhiteSpace(branchName)
+                ? branchName
+                : (GitInstaller.GetCheckedoutBranch(clonePath) ?? PyRevitLabsConsts.TargetBranch);
             var commitSha = GitInstaller.GetHeadCommit(clonePath);
-            InstallForClone(clonePath, repoId, commitSha, branchName, mode: mode);
+            InstallForClone(clonePath, repoId, commitSha, resolvedBranch, mode: mode);
         }
 
         public static void InstallForImageClone(
@@ -138,6 +136,13 @@ namespace pyRevitLabs.Common {
                 }
             }
 
+            // Published v* releases attach a durable signed bin zip; try it when SHA assets are absent.
+            if (!BinArtifactSupport.IsSupportedCiBinBranch(branchName)
+                && !string.IsNullOrWhiteSpace(branchName)
+                && TryDownloadVersionTagBin(repoId, branchName, destPath)) {
+                return true;
+            }
+
             if (!allowBranchFallback || !BinArtifactSupport.IsSupportedCiBinBranch(branchName))
                 return false;
 
@@ -161,6 +166,22 @@ namespace pyRevitLabs.Common {
             foreach (var releaseRepoId in BinArtifactSupport.GetReleaseDownloadRepos(repoId)) {
                 if (GithubReleaseBinAPI.TryDownloadReleaseAsset(releaseRepoId, branchAsset, destPath)) {
                     usedBranchFallback = true;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryDownloadVersionTagBin(string repoId, string tagName, string destPath) {
+            var tagAsset = GithubReleaseBinAPI.BuildVersionTagBinAssetName(tagName);
+            foreach (var releaseRepoId in BinArtifactSupport.GetReleaseDownloadRepos(repoId)) {
+                if (GithubReleaseBinAPI.TryDownloadReleaseAsset(
+                    releaseRepoId,
+                    tagAsset,
+                    destPath,
+                    releaseTag: tagName)) {
+                    logger.Info("Installed signed binaries from GitHub Release \"{0}\".", tagName);
                     return true;
                 }
             }

--- a/dev/pyRevitLabs/pyRevitLabs.Common/BinArtifactSupport.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/BinArtifactSupport.cs
@@ -21,6 +21,16 @@ namespace pyRevitLabs.Common {
             return false;
         }
 
+        public static bool IsVersionTagRef(string refName) {
+            if (string.IsNullOrWhiteSpace(refName))
+                return false;
+
+            var normalized = refName.Trim();
+            return normalized.Length >= 2
+                && (normalized[0] == 'v' || normalized[0] == 'V')
+                && char.IsDigit(normalized[1]);
+        }
+
         public static bool IsForkRepo(string repoId) {
             return !string.Equals(
                 repoId?.Trim(),

--- a/dev/pyRevitLabs/pyRevitLabs.Common/GithubReleaseBinAPI.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.Common/GithubReleaseBinAPI.cs
@@ -9,13 +9,15 @@ namespace pyRevitLabs.Common {
         private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
         public const string CiBinariesReleaseTag = "ci-binaries";
+        public const string VersionTagBinAssetPrefix = "bin-";
 
-        public static string BuildReleaseAssetUrl(string repoId, string assetFileName) {
+        public static string BuildReleaseAssetUrl(string repoId, string assetFileName, string releaseTag = null) {
+            var tag = string.IsNullOrWhiteSpace(releaseTag) ? CiBinariesReleaseTag : releaseTag.Trim();
             return string.Format(
                 "https://github.com/{0}/releases/download/{1}/{2}",
                 repoId,
-                CiBinariesReleaseTag,
-                assetFileName);
+                Uri.EscapeDataString(tag),
+                Uri.EscapeDataString(assetFileName));
         }
 
         public static string BuildShaAssetName(string commitSha) {
@@ -29,11 +31,19 @@ namespace pyRevitLabs.Common {
                 branchName);
         }
 
-        public static bool TryDownloadReleaseAsset(string repoId, string assetFileName, string destPath) {
+        public static string BuildVersionTagBinAssetName(string tagName) {
+            return VersionTagBinAssetPrefix + tagName.Trim() + ".zip";
+        }
+
+        public static bool TryDownloadReleaseAsset(
+            string repoId,
+            string assetFileName,
+            string destPath,
+            string releaseTag = null) {
             if (!CommonUtils.CheckInternetConnection())
                 throw new pyRevitNoInternetConnectionException();
 
-            var url = BuildReleaseAssetUrl(repoId, assetFileName);
+            var url = BuildReleaseAssetUrl(repoId, assetFileName, releaseTag);
             logger.Debug("Trying public release asset \"{0}\"", url);
 
             try {

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClones.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClones.cs
@@ -288,7 +288,8 @@ namespace pyRevitLabs.PyRevit
                                           string branchName = null,
                                           string repoUrl = null,
                                           string destPath = null,
-                                          GitInstallerCredentials credentials = null)
+                                          GitInstallerCredentials credentials = null,
+                                          bool installBinaries = true)
         {
             if (destPath != null)
                 destPath = CommonUtils.ExpandEnvironmentPath(destPath);
@@ -339,7 +340,12 @@ namespace pyRevitLabs.PyRevit
                 try
                 {
                     PyRevitClone.VerifyCloneValidity(clonedPath);
-                    InstallBinariesForRepoClone(clonedPath, repoSourcePath, BinArtifactInstallMode.Clone);
+                    if (installBinaries)
+                        InstallBinariesForRepoClone(
+                            clonedPath,
+                            repoSourcePath,
+                            BinArtifactInstallMode.Clone,
+                            repoBranch);
                     logger.Debug("Clone successful \"{0}\"", clonedPath);
                     RegisterClone(cloneName, clonedPath, forceUpdate: true);
                 }
@@ -562,12 +568,18 @@ namespace pyRevitLabs.PyRevit
 
                 logger.Info("Package deployed and registered.");
             }
+            catch (pyRevitBinArtifactNotFoundException)
+            {
+                throw;
+            }
             catch (PyRevitException ex)
             {
                 var errMsg = ex.Message;
                 if (errMsg != null && errMsg.IndexOf('%') >= 0)
                     errMsg += " Path may contain unexpanded environment variables; ensure TEMP and --dest resolve to absolute paths.";
-                logger.Error("Can not find a valid clone inside extracted package. | {0}", errMsg);
+                throw new PyRevitException(
+                    string.Format("Can not find a valid clone inside extracted package. | {0}", errMsg),
+                    ex);
             }
         }
 
@@ -767,9 +779,10 @@ namespace pyRevitLabs.PyRevit
         private static void InstallBinariesForRepoClone(
             string clonePath,
             string repoUrl,
-            BinArtifactInstallMode mode) {
+            BinArtifactInstallMode mode,
+            string branchName = null) {
             try {
-                BinArtifactInstaller.InstallForRepoClone(clonePath, repoUrl, mode);
+                BinArtifactInstaller.InstallForRepoClone(clonePath, repoUrl, mode, branchName);
             }
             catch (pyRevitMissingGithubTokenException) {
                 throw;

--- a/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClones.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.PyRevit/PyRevitClones.cs
@@ -568,8 +568,12 @@ namespace pyRevitLabs.PyRevit
 
                 logger.Info("Package deployed and registered.");
             }
-            catch (pyRevitBinArtifactNotFoundException)
+            catch (pyRevitBinArtifactNotFoundException ex)
             {
+                logger.Warn(
+                    "Image clone deployed but CI binaries could not be installed at \"{0}\" | {1}",
+                    destPath,
+                    ex.Message);
                 throw;
             }
             catch (PyRevitException ex)

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.BinArtifactSupport.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.BinArtifactSupport.cs
@@ -39,6 +39,24 @@ namespace pyRevitLabs.UnitTests.Common {
         }
 
         [TestMethod]
+        public void IsVersionTagRef_PublishedReleaseTags_Test() {
+            Assert.IsTrue(BinArtifactSupport.IsVersionTagRef("v6.5.3.26176+2017"));
+            Assert.IsTrue(BinArtifactSupport.IsVersionTagRef("V6.5.3.26176+2017"));
+            Assert.IsTrue(BinArtifactSupport.IsVersionTagRef(" v4.8.16 "));
+        }
+
+        [TestMethod]
+        public void IsVersionTagRef_NonVersionRefs_Test() {
+            Assert.IsFalse(BinArtifactSupport.IsVersionTagRef("develop"));
+            Assert.IsFalse(BinArtifactSupport.IsVersionTagRef("master"));
+            Assert.IsFalse(BinArtifactSupport.IsVersionTagRef("feature/foo"));
+            Assert.IsFalse(BinArtifactSupport.IsVersionTagRef("version"));
+            Assert.IsFalse(BinArtifactSupport.IsVersionTagRef("v"));
+            Assert.IsFalse(BinArtifactSupport.IsVersionTagRef(null));
+            Assert.IsFalse(BinArtifactSupport.IsVersionTagRef(string.Empty));
+        }
+
+        [TestMethod]
         public void GetReleaseDownloadRepos_ForkIncludesUpstream_Test() {
             var repos = BinArtifactSupport.GetReleaseDownloadRepos("myorg/pyRevit");
             Assert.AreEqual(2, repos.Count);

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.BinArtifactSupport.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.BinArtifactSupport.cs
@@ -33,6 +33,7 @@ namespace pyRevitLabs.UnitTests.Common {
         [TestMethod]
         public void IsSupportedCiBinBranch_OtherBranches_Test() {
             Assert.IsFalse(BinArtifactSupport.IsSupportedCiBinBranch("feature/foo"));
+            Assert.IsFalse(BinArtifactSupport.IsSupportedCiBinBranch("v6.5.3.26176+2017"));
             Assert.IsFalse(BinArtifactSupport.IsSupportedCiBinBranch(null));
             Assert.IsFalse(BinArtifactSupport.IsSupportedCiBinBranch(string.Empty));
         }

--- a/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.GithubReleaseBinAPI.cs
+++ b/dev/pyRevitLabs/pyRevitLabs.UnitTests/pyRevitLabs.UnitTests.GithubReleaseBinAPI.cs
@@ -25,5 +25,22 @@ namespace pyRevitLabs.UnitTests.Common {
             var name = GithubReleaseBinAPI.BuildBranchLatestAssetName("develop");
             Assert.AreEqual("unsigned-bin-develop-latest.zip", name);
         }
+
+        [TestMethod]
+        public void BuildVersionTagBinAssetName_Test() {
+            var name = GithubReleaseBinAPI.BuildVersionTagBinAssetName("v6.5.3.26176+2017");
+            Assert.AreEqual("bin-v6.5.3.26176+2017.zip", name);
+        }
+
+        [TestMethod]
+        public void BuildReleaseAssetUrl_VersionTagEncodesPlus_Test() {
+            var url = GithubReleaseBinAPI.BuildReleaseAssetUrl(
+                "pyrevitlabs/pyRevit",
+                "bin-v6.5.3.26176+2017.zip",
+                "v6.5.3.26176+2017");
+            Assert.AreEqual(
+                "https://github.com/pyrevitlabs/pyRevit/releases/download/v6.5.3.26176%2B2017/bin-v6.5.3.26176%2B2017.zip",
+                url);
+        }
     }
 }

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -21,7 +21,7 @@ pyRevit's pipeline is split across workflows in [`.github/workflows/`](https://g
 |----------|------|--------------|
 | **`pyRevit CI`** | [`ci.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/ci.yml) | Runs `dotnet run -- ci` to build unsigned DLLs, runs `dotnet test` on the build project, uploads `unsigned-bin-<sha>` (Actions artifact for WIP/release), and publishes the same zip to the public **`ci-binaries`** GitHub Release (for `pyrevit clone`). Runs on every push to `develop` / `master` / `v*` tag (with a path filter), on PRs to those branches, and on manual dispatch. |
 | **`pyRevit WIP`** | [`wip.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/wip.yml) | Downloads CI artifacts, runs `dotnet run -- pack sign` under the **`production`** environment, and uploads signed WIP installers. |
-| **`pyRevit Release`** | [`release.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/release.yml) | On `v*` tag pushes, waits for CI, runs `dotnet run -- release pack sign publish` under **`production`**, then notifies linked issues. |
+| **`pyRevit Release`** | [`release.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/release.yml) | On `v*` tag pushes, waits for CI, runs `dotnet run -- release pack sign publish` under **`production`**, attaches signed `bin-v{version}.zip` to the draft GitHub Release, then notifies linked issues. |
 | **`Update Winget manifests`** | [`winget.yml`](https://github.com/pyrevitlabs/pyRevit/blob/develop/.github/workflows/winget.yml) | After a GitHub release is **published**, runs `dotnet run -- winget` to submit WinGet manifest PRs. Strips `ElevationRequirement: elevationProhibited` from generated user-scope installers before submit (see Troubleshooting). |
 
 The CI **`notify`** job (develop pushes only) runs `dotnet run -- notify` inline in `ci.yml` with `issues: write` and does **not** use the `production` environment.
@@ -59,11 +59,12 @@ The stamping steps (`set year`, `set build wip|release`, `set products`) only ru
 
 **User workflows** (full commands for run-only vs C# contributor): [Developer Guide — Clone workflows](dev-guide.md#clone-workflows).
 
-End users and contributors who only need to **run** pyRevit (not build C#) get `bin/` via `pyrevit clone` or `pyrevit clones update` on **`develop`** or **`master`** — **no GitHub token** on the public repo when Release assets are available. C# contributors use `git clone`, local `dotnet run -- ci`, and `pyrevit clones update --skip-bin` instead — see Profile 2 in the dev guide.
+End users and contributors who only need to **run** pyRevit (not build C#) get `bin/` via `pyrevit clone` or `pyrevit clones update` on **`develop`**, **`master`**, or a **published `v*` release tag** — **no GitHub token** on the public repo when Release assets are available. C# contributors use `git clone`, local `dotnet run -- ci`, and `pyrevit clones update --skip-bin` instead — see Profile 2 in the dev guide.
 
 | Consumer | Source | Auth |
 |----------|--------|------|
-| `pyrevit clone` / `clones update` | GitHub Release **`ci-binaries`** assets (fork → upstream SHA fallback) | None (anonymous HTTPS) |
+| `pyrevit clone` / `clones update` (`develop` / `master`) | GitHub Release **`ci-binaries`** assets (fork → upstream SHA fallback) | None (anonymous HTTPS) |
+| `pyrevit clone --branch=v*` | GitHub Release **`bin-v{version}.zip`** on the published version tag (signed `bin/`) | None (anonymous HTTPS) |
 | `pyrevit clone` / `clones update` (token fallback) | GitHub Packages **`PyRevit.UnsignedBin`** NuGet mirror | `GITHUBTOKEN` (`read:packages`) |
 | `pyrevit clone` / `clones update` (token fallback) | Actions artifact `unsigned-bin-<sha>` | `GITHUBTOKEN` (`actions:read`) |
 | WIP / release pack pipelines | Actions artifact `unsigned-bin-<sha>` | `GITHUB_TOKEN` in CI |
@@ -81,15 +82,19 @@ Anonymous download URL pattern:
 ```text
 https://github.com/pyrevitlabs/pyRevit/releases/download/ci-binaries/unsigned-bin-{sha}.zip
 https://github.com/pyrevitlabs/pyRevit/releases/download/ci-binaries/unsigned-bin-develop-latest.zip
+https://github.com/pyrevitlabs/pyRevit/releases/download/v{version}/bin-v{version}.zip
 ```
+
+`+` in a version tag is URL-encoded as `%2B` (for example `v6.5.3.26176%2B2017`). Tag clones work after the GitHub Release is **published**; draft assets are not anonymous.
 
 CLI download order:
 
-1. Release asset for clone remote + commit SHA
+1. Release asset for clone remote + commit SHA (`ci-binaries`)
 2. Release asset for upstream (`pyrevitlabs/pyRevit`) + same SHA (synced forks)
-3. Release branch-latest on clone remote, then upstream
-4. NuGet `PyRevit.UnsignedBin` (when `GITHUBTOKEN` is set)
-5. Actions artifacts (when `GITHUBTOKEN` is set)
+3. Signed `bin-v{version}.zip` on the version GitHub Release when `--branch` is not `develop`/`master`
+4. Release branch-latest on clone remote, then upstream (`develop` / `master` only)
+5. NuGet `PyRevit.UnsignedBin` (when `GITHUBTOKEN` is set)
+6. Actions artifacts (when `GITHUBTOKEN` is set)
 
 See also [`build/README.md`](../build/README.md) and the [developer guide](dev-guide.md).
 
@@ -152,7 +157,7 @@ Releases are no longer auto-triggered by merging into `master`. A maintainer run
 4. Pushing the tag triggers two workflows in parallel:
 
     - **`ci.yml`** rebuilds DLLs on the tagged commit and uploads `unsigned-bin-<sha>` (DLLs only; installers are no longer built in CI).
-    - **`release.yml`** starts immediately and polls for the matching CI run (via `gh run watch`). The **`release`** job downloads CI artifacts, runs `dotnet run -- release pack sign publish` under **`production`** (sign via `sign code trusted-signing`, draft GitHub Release, Chocolatey push). **`notify`** then posts to linked issues. After you publish the draft release, **`winget.yml`** submits WinGet manifest PRs.
+    - **`release.yml`** starts immediately and polls for the matching CI run (via `gh run watch`). The **`release`** job downloads CI artifacts, runs `dotnet run -- release pack sign publish` under **`production`** (sign via `sign code trusted-signing`, draft GitHub Release including signed `bin-v{version}.zip` for `pyrevit clone --branch=v*`, Chocolatey push). **`notify`** then posts to linked issues. After you publish the draft release, **`winget.yml`** submits WinGet manifest PRs.
 
 5. Open the draft release on GitHub, review the auto-generated notes, then publish it.
 
@@ -249,6 +254,7 @@ CI invokes the ModularPipelines project from [`build/`](../build/) via `dotnet r
 - **Notify failed on empty `release_url`**: the **`release`** job did not write `dist/github-release-url.txt` during publish (check **`Run release pipeline`** logs for `Deployment GitHub`). Re-run **`release`**, then re-run **`notify`**. The notify job receives the URL from the release job output; it no longer looks up releases by tag (tags containing `+` break `gh release view`).
 - **Draft release exists but `notify` did not run**: the **`release`** job must finish successfully (including Choco push) before **`notify`** starts. Fix or re-run **`release`**, then re-run **`notify`** if the draft release URL is already available.
 - **WinGet validation fails with `0x8A150056` / `elevationProhibited`**: WinGet's validation VM uses an administrator-capable account. Inno user installers built with `PrivilegesRequired=lowest` still block installation there even after removing `ElevationRequirement: elevationProhibited` from the manifest (WinGet reads the restriction from the installer). The `winget` pipeline publishes **machine-scope admin installers only** and strips `elevationProhibited` if `wingetcreate` adds it. Per-user installers remain on GitHub Releases. Pushing a manifest update to the winget-pkgs PR re-triggers validation automatically (`@wingetbot run` requires Moderator).
+- **`pyrevit clone --branch=v*` fails to find binaries**: the GitHub Release for that tag must be **published** (draft assets are not anonymous). Confirm `bin-v{version}.zip` is listed on the release, then retry. Use `--skip-bin` only when you will sideload `bin/` yourself.
 
 ## Related reading
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -54,20 +54,26 @@ Make sure to uncheck the "Copy the master branch only" option, since we mostly u
 
 ### Clone workflows
 
-`bin/` is **not in git**. Choose one workflow below. Only **`develop`** and **`master`** support CI binary download. Details on CI assets and fallbacks: [CI/CD — Prebuilt binaries for clone](ci-cd.md#prebuilt-binaries-for-clone).
+`bin/` is **not in git**. Choose one workflow below. **`develop`**, **`master`**, and published **`v*`** release tags support binary download. Details on CI assets and fallbacks: [CI/CD — Prebuilt binaries for clone](ci-cd.md#prebuilt-binaries-for-clone).
 
 | Profile | You want to… | Get source via | Get `bin/` via |
 |---------|----------------|----------------|----------------|
-| **1 — Run in Revit** | Use pyRevit without building C# | `pyrevit clone` | Public Release `ci-binaries` (no token on upstream when assets exist) |
+| **1 — Run in Revit** | Use pyRevit without building C# | `pyrevit clone` | Public Release `ci-binaries` (`develop`/`master`) or signed `bin-v{version}.zip` on a published `v*` tag |
 | **2 — C# contributor** | Change DLLs and debug in Visual Studio | `git clone` | `dotnet run -- ci` in [`build/`](../build/) |
 
 #### Profile 1 — Run in Revit (CI binaries)
 
-Uses the pyRevit CLI to clone git source **and** download pre-built `bin/` from the [`ci-binaries`](https://github.com/pyrevitlabs/pyRevit/releases/tag/ci-binaries) release. Normal path on `pyrevitlabs/pyRevit` needs no `GITHUBTOKEN`. Synced forks use upstream Release assets for the same commit SHA.
+Uses the pyRevit CLI to clone git source **and** download pre-built `bin/` from the [`ci-binaries`](https://github.com/pyrevitlabs/pyRevit/releases/tag/ci-binaries) release (or the matching GitHub Release when `--branch` is a `v*` tag). Normal path on `pyrevitlabs/pyRevit` needs no `GITHUBTOKEN`. Synced forks use upstream Release assets for the same commit SHA.
 
 ```shell
 pyrevit clone dev --source <repo-url> --dest <parent-directory> --branch develop
 pyrevit attach dev default --installed
+```
+
+Pin a published release (after the GitHub Release is published, not while it is still a draft):
+
+```shell
+pyrevit clone fleet base --branch=v6.5.3.26176+2017 --dest <parent-directory>
 ```
 
 Refresh source and binaries later:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Since #3425 removed `bin/` from git, `pyrevit clone … --branch=v6.5.x` fails before any download: the CLI rejects refs that are not `develop`/`master`, and release tags never get a durable public bin payload (the tag CI artifact is deleted after installers are built).

This restores pinned fleet clones for **future published** `v*` GitHub Releases:

1. **Release pipeline** attaches a signed `bin-v{version}.zip` to the version GitHub Release (Octokit upload, so tags with `+` work).
2. **CLI** no longer hard-throws for non-`develop`/`master` refs. It still probes SHA assets on `ci-binaries`, then `releases/download/{tag}/bin-{tag}.zip`, and keeps branch-latest fallback for `develop`/`master` only.
3. Image clones **fail with a non-zero exit** when binaries cannot be installed, instead of registering a bin-less clone.
4. `pyrevit clone --skip-bin` is available for orgs that sideload `bin/` themselves.

`+` in a version tag is URL-encoded as `%2B` on download. Tag clones work after the GitHub Release is **published**; draft assets are not anonymous.

## Relationship to #3556

Does **not** duplicate [#3556](https://github.com/pyrevitlabs/pyRevit/pull/3556) (#3555). That PR keeps `ci-binaries` prune from deleting the SHA it just uploaded and refreshes **unsigned** `unsigned-bin-master-latest.zip` from tag CI so clone-of-**master** stays current.

This PR is the fleet **pin-a-tag** path: CLI accepts `v*` refs and the version GitHub Release gets a durable **signed** `bin-v{version}.zip`. Different assets, different destinations, no shared workflow YAML.

**Merge-conflict surface:** both edit `docs/ci-cd.md` and `build/README.md` (same paragraphs about clone binaries / `release.yml`). Workflows do not overlap (`ci.yml` / `release.yml` vs C# publish module + CLI). Merge the later PR’s docs hunks by combining both notes.

If both land, a tag clone will try the unsigned SHA zip on `ci-binaries` first (helped by #3556 keeping tag SHAs), then the signed per-release zip from this PR.

## Checklist

- [x] Code follows project conventions
- [x] Changes are tested and verified to work as expected (`dotnet test tests/Build.Tests.csproj -c Release`; Common/PyRevit compile)

## Related Issues

- Resolves #3554

## Additional Notes

Already-shipped 6.5.x GitHub Releases do **not** gain `bin-v{version}.zip` automatically. Re-running `release.yml` on an existing tag would try to create a second GitHub Release and fail. To pin an older 6.5.x tag today, either:

- upload `bin-v{tag}.zip` onto that published release, then use a CLI that includes this change, or
- `pyrevit clone … --branch=v… --skip-bin` and sideload binaries (the workaround described in the issue).

Future tagged releases pick this up once this is merged and the next `v*` tag is published.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d896595c-29a8-4715-8f84-13bee3012af3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d896595c-29a8-4715-8f84-13bee3012af3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

