### PR TITLE
Add Sendit and Groundit to the extensions catalog

### DIFF
--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -343,6 +343,32 @@
             "website": "https://github.com/jason-svn/WWPTools_Publicly_Shared",
             "image": "",
             "dependencies": []
+        },
+        {
+            "builtin": "False",
+            "type": "extension",
+            "rocket_mode_compatible": "True",
+            "name": "Sendit",
+            "description": "Drawing-production tools for Revit. Sheet Manager gives you an editable sheet grid with bulk renumber and rename, find and replace, batch create from CSV, a revision manager, sheet sets, and PDF/CSV export with filename templating. Issue Manager exports issued sheets as PDFs into a dated folder with matching DWGs, maintains a running issue register CSV, and creates a Drawing Issue Register schedule in Revit. Also includes Sun Eye Views for solar analysis and Sync Sprint, a shortcut-practice game that runs while you synchronise. Themed to Revit's dark and light UI (Revit 2024+). Free, MIT-licensed.",
+            "author": "lewismconte",
+            "author_profile": "https://github.com/lewismconte",
+            "url": "https://github.com/lewismconte/sendit.git",
+            "website": "https://github.com/lewismconte/sendit",
+            "image": "",
+            "dependencies": []
+        },
+        {
+            "builtin": "False",
+            "type": "extension",
+            "rocket_mode_compatible": "True",
+            "name": "Groundit",
+            "description": "Import real-world site context into Revit. Draw a box on a map in your browser and get it back as a linked site model: a toposolid from real elevation data, building masses at OpenStreetMap heights with courtyards as openings, and roads as surfaces at real carriageway width draped on the terrain. Update Site re-downloads a linked site and reloads it in place, keeping its position and view overrides. No API keys, no accounts and no GIS software - elevation comes from the AWS Terrain Tiles open dataset and vectors from OpenStreetMap. Free, MIT-licensed.",
+            "author": "lewismconte",
+            "author_profile": "https://github.com/lewismconte",
+            "url": "https://github.com/lewismconte/groundit.git",
+            "website": "https://github.com/lewismconte/groundit",
+            "image": "",
+            "dependencies": []
         }
     ]
 }

--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -349,7 +349,7 @@
             "type": "extension",
             "rocket_mode_compatible": "True",
             "name": "Sendit",
-            "description": "Drawing-production tools for Revit. Sheet Manager gives you an editable sheet grid with bulk renumber and rename, find and replace, batch create from CSV, a revision manager, sheet sets, and PDF/CSV export with filename templating. Issue Manager exports issued sheets as PDFs into a dated folder with matching DWGs, maintains a running issue register CSV, and creates a Drawing Issue Register schedule in Revit. Also includes Sun Eye Views for solar analysis and Sync Sprint, a shortcut-practice game that runs while you synchronise. Themed to Revit's dark and light UI (Revit 2024+). Free, MIT-licensed.",
+            "description": "Drawing-production tools for Revit. Sheet Manager gives you an editable sheet grid with bulk renumber and rename, find and replace, batch create from CSV, a revision manager, sheet sets, and PDF/CSV export with filename templating. View Manager does the same for views: bulk rename, apply templates, set scale, detail level and discipline, flag views not placed on a sheet, plus a template editor that can export and import view templates as JSON for office-standard reuse. Issue Manager exports issued sheets as PDFs into a dated folder with matching DWGs, maintains a running issue register CSV, and creates a Drawing Issue Register schedule in Revit. Sync Sprint turns waiting on Synchronize with Central into shortcut practice. Themed to Revit's dark and light UI (Revit 2024+). Free, MIT-licensed.",
             "author": "lewismconte",
             "author_profile": "https://github.com/lewismconte",
             "url": "https://github.com/lewismconte/sendit.git",


### PR DESCRIPTION
Adds two extensions to the catalog. Both are free, MIT-licensed, public, and
structured with the `.tab` folder and `extension.json` at the repository root
as the contributing notes require.

### Sendit — https://github.com/lewismconte/sendit

Drawing-production tools. Sheet Manager is an editable sheet grid with bulk
renumber and rename, batch create from CSV, a revision manager, sheet sets,
and PDF/CSV export with filename templating. View Manager does the same for
views, including a template editor that exports and imports view templates as
JSON for office-standard reuse. Issue Manager produces dated PDF/DWG issue
folders, a running issue register CSV, and a Drawing Issue Register schedule.
Sync Sprint turns waiting on Synchronize with Central into shortcut practice.
Themed to Revit's dark and light UI on 2024+.

### Groundit — https://github.com/lewismconte/groundit

Imports real-world site context. You draw a box on a map in your browser and
get it back as a linked site model: a toposolid from real elevation data,
building masses at OpenStreetMap heights, and roads as surfaces at real
carriageway width draped on the terrain. An Update button re-downloads a
linked site and reloads it in place, preserving its position and view
overrides.

No API keys or accounts are needed — elevation comes from the AWS Terrain
Tiles open data set (terrarium-encoded PNGs, decoded in-process) and vectors
from OpenStreetMap via Overpass. Attribution for both is in the README.
Verified working on Revit 2027.1 with pyRevit 6.5.3.

### Notes

- Only `extensions/extensions.json` is touched; no existing entry is modified.
- Both are submitted in one PR to avoid two branches conflicting on the same
  array — happy to split them if you would rather review separately.
- `rocket_mode_compatible` is `True` for both: no `System.Windows.Application`
  construction, no module-level event handlers or cached documents, and
  `sys.path` edits are guarded.
