### PR TITLE
Add Cloud Agent development environment (docs, lint, Go CLI)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,12 @@
+{
+  "name": "pyRevit (docs + tooling)",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "docs-server",
+      "command": "cd /workspace && PIPENV_VENV_IN_PROJECT=1 pipenv run mkdocs serve -a 0.0.0.0:8000"
+    }
+  ],
+  "ports": [8000]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Cloud Agent bootstrap for pyRevit's Linux-supported development surface:
+# the mkdocs documentation site, ruff docstring linting, and the Go CLI
+# autocomplete generator. The Revit add-in and product DLLs are built only on
+# Windows (see .github/workflows/ci.yml) and are intentionally out of scope on
+# a Linux Cloud Agent. Kept idempotent so it can rerun against cached state.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Python 3.14 toolchain, matching .github/workflows/docs.yml and the Pipfile.
+if ! command -v python3.14 >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y software-properties-common
+  sudo add-apt-repository -y ppa:deadsnakes/ppa
+  sudo apt-get update
+  sudo apt-get install -y python3.14 python3.14-venv python3.14-dev
+fi
+
+# pipenv on the system PATH so `pipenv run ...` works in any shell.
+if ! command -v pipenv >/dev/null 2>&1; then
+  sudo pip3 install pipenv --break-system-packages
+fi
+
+# Docs and lint dependencies, resolved from the committed Pipfile.lock.
+export PIPENV_VENV_IN_PROJECT=1
+pipenv --python /usr/bin/python3.14 sync
+
+# Go modules for the pyRevit CLI autocomplete generator.
+if command -v go >/dev/null 2>&1; then
+  (cd dev/pyRevitLabs/pyRevitCLIAutoComplete && go mod download)
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ build/tests/bin/*
 build/tests/obj/*
 ci-stamped/
 ci-bin-manifest.json
+
+# Python virtualenv created by pipenv (PIPENV_VENV_IN_PROJECT)
+.venv/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for pyRevit covering the parts of the project that build and run on Linux:

- **Documentation site** — `mkdocs build` / `mkdocs serve` on Python 3.14 via `pipenv` (matches `.github/workflows/docs.yml`).
- **Docstring linting** — `ruff` docstring checks (`pipenv run check-docstrings`).
- **Go CLI autocomplete generator** — `dev/pyRevitLabs/pyRevitCLIAutoComplete`.

The Revit add-in and product DLLs are built only on Windows (`.github/workflows/ci.yml` runs on `windows-2025`), so they are intentionally out of scope for a Linux Cloud Agent.

## Changes

- `.cursor/environment.json` — `install` command plus a `docs-server` terminal running `mkdocs serve` on port `8000`.
- `.cursor/install.sh` — idempotent bootstrap: installs Python 3.14 (deadsnakes) + `pipenv`, runs `pipenv sync` from the committed `Pipfile.lock`, and pre-downloads Go modules.
- `.gitignore` — ignores the in-project `.venv/` created by `pipenv`.

## Validation

| Check | Result |
| --- | --- |
| `pipenv sync` on Python 3.14.6 | All dependencies installed from `Pipfile.lock` |
| `mkdocs build` | Documentation site built successfully |
| Docs site served + browsed (home, Reference API tree, module pages, search) | Rendered correctly end to end |
| `ruff` docstring check (`pipenv run check-docstrings`) | Runs against `pyrevitlib/pyrevit` |
| Go autocomplete build + run | Builds; emits shell completions |
| `install.sh` idempotence | Runs cleanly twice |
| Draft environment build (clean checkout + install) | SUCCEEDED |
| Fresh Cloud Agent (booted from tested build) | Python 3.14.6 venv, docs build, ruff, and Go CLI all pass; clean git status |

The `docs-server` terminal and `ports` live in the committed `.cursor/environment.json` (repository-managed config takes precedence once merged).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea9f46b8-3a22-4bb5-9e5b-8364ee9b44e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea9f46b8-3a22-4bb5-9e5b-8364ee9b44e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

