### PR TITLE
Fix tmpgfx import on Revit 2021 and earlier

### DIFF
--- a/extensions/pyRevitDevTools.extension/pyRevitDev.tab/Developer Examples.panel/TemporaryGraphics.pushbutton/bundle.yaml
+++ b/extensions/pyRevitDevTools.extension/pyRevitDev.tab/Developer Examples.panel/TemporaryGraphics.pushbutton/bundle.yaml
@@ -1,3 +1,4 @@
 title: "Temporary\nGraphics"
+min_revit_version: 2022
 engine:
   persistent: true

--- a/pyrevitlib/pyrevit/revit/__init__.py
+++ b/pyrevitlib/pyrevit/revit/__init__.py
@@ -50,10 +50,11 @@ from pyrevit.revit import features
 _perfmark("pyrevit.revit:after features")
 from pyrevit.revit import bim360
 from pyrevit.revit import dc3dserver
-from pyrevit.revit import tmpgfx
+if HOST_APP.is_newer_than(2021):
+    from pyrevit.revit import tmpgfx
 _perfmark("pyrevit.revit:after bim360/dc3dserver/tmpgfx (exit)")
 from pyrevit.revit import avf
-_perfmark("pyrevit.revit:after bim360/dc3dserver/avf (exit)")
+_perfmark("pyrevit.revit:after avf (exit)")
 
 
 #pylint: disable=W0703,C0302,C0103


### PR DESCRIPTION
## Description

Guard the tmpgfx import and Temporary Graphics API initialization for Revit versions prior to 2022.

This prevents pyrevit.revit from failing during initialization when TemporaryGraphicsHandlerService is unavailable.

Related forum issue: https://discourse.pyrevitlabs.io/t/revit-2020-and-2021-not-loading-in-6-5-4-update/10460

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #3571 

