### PR TITLE
Fix/lib extension root on startup search paths

### DIFF
--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/AssemblyMaker/AssemblyBuilderService.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/AssemblyMaker/AssemblyBuilderService.cs
@@ -76,13 +76,15 @@ namespace pyRevitAssemblyBuilder.AssemblyMaker
             LoadExtensionModules(extension);
 
             // Include generation-time inputs that affect emitted command types, so cache invalidates
-            // when runtime behavior changes (e.g. rocket mode toggles or loader binary updates).
+            // when runtime behavior changes (rocket mode, generator schema, or library-extension
+            // search paths — those paths are compiled into each command).
             string strategySeed = string.Join("|",
                 _buildStrategy.ToString(),
                 $"rocket:{rocketMode}",
                 $"rocket_compat:{extension.RocketModeCompatible}",
                 $"builder:{GetAssemblyBuildFingerprint()}",
-                $"runtime:{GetRuntimeBuildFingerprint()}");
+                $"runtime:{GetRuntimeBuildFingerprint()}",
+                $"libs:{LibraryExtensionSearchPaths.CacheSeed(libraryExtensions)}");
             string hash = GetStableHash(extension.GetHash(strategySeed) + _revitVersion).Substring(0, 16);
             string fileName = $"pyRevit_{_revitVersion}_{hash}_{extension.Name}.dll";
 
@@ -390,18 +392,14 @@ namespace pyRevitAssemblyBuilder.AssemblyMaker
             return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
         }
 
-        // Cache invalidation must trigger when the loader's command-type generation can
-        // change between pyRevit versions, but not on every rebuild/redeploy. Key it on the
-        // loader's semantic version only: previously this also mixed in the DLL file write
-        // time, which changed on every loader rebuild/update and forced every extension to
-        // recompile on each load. Computed once per session.
-        //
-        // Developer caveat: if you change code-generation logic without bumping the
-        // assembly version, the cache will serve the previously built DLLs. To force
-        // a rebuild during generator development, delete
-        // %APPDATA%/pyRevit/{revitVersion}/pyRevit_*.dll (the existing
-        // cleanup_assembly_files also clears unloaded ones on the next single-instance
-        // shutdown).
+        // Cache invalidation must trigger when emitted command types change, but not on
+        // every local rebuild. Do not mix in the DLL file write time: that forced every
+        // extension to recompile on each loader rebuild.
+        // Bump CommandTypeGeneratorSchema when generation logic changes without a
+        // pyRevit version bump. Library-extension directories are hashed separately
+        // in strategySeed so adding/removing a .lib or nested lib/ also invalidates.
+        private const string CommandTypeGeneratorSchema = "lib-root-1";
+
         private static readonly string _assemblyBuildFingerprint = ComputeAssemblyBuildFingerprint();
 
         private static string GetAssemblyBuildFingerprint() => _assemblyBuildFingerprint;
@@ -423,11 +421,12 @@ namespace pyRevitAssemblyBuilder.AssemblyMaker
         {
             try
             {
-                return Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0";
+                var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0";
+                return version + "|" + CommandTypeGeneratorSchema;
             }
             catch
             {
-                return "0";
+                return "0|" + CommandTypeGeneratorSchema;
             }
         }
 

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/AssemblyMaker/CommandTypeGenerator.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/AssemblyMaker/CommandTypeGenerator.cs
@@ -85,13 +85,7 @@ namespace pyRevitAssemblyBuilder.AssemblyMaker
             // typemaker.make_bundle_types(); this HashSet provides equivalent safety.
             var emittedClassNames = new HashSet<string>(StringComparer.Ordinal);
 
-            // Perf fix for #3268 issue #9: Materialize library extension directories
-            // ONCE before the command loop.  Previously .ToList() was called per command,
-            // creating hundreds of unnecessary list copies for the default install.
-            var libExtDirectories = libraryExtensions?
-                .Select(le => le.Directory)
-                .Where(d => !string.IsNullOrEmpty(d))
-                .ToList();
+            var libExtDirectories = LibraryExtensionSearchPaths.Collect(libraryExtensions);
 
             var commands = extension.CollectCommandComponents().ToList();
             var totalCommands = commands.Count;
@@ -141,12 +135,7 @@ namespace pyRevitAssemblyBuilder.AssemblyMaker
                 // Add binary paths from component hierarchy for module DLLs
                 searchPathsList.AddRange(extension.CollectBinaryPaths(cmd));
 
-                // Add all library extension directories
-                // Add all library extension directories (pre-materialized above)
-                if (libExtDirectories != null)
-                {
-                    searchPathsList.AddRange(libExtDirectories);
-                }
+                searchPathsList.AddRange(libExtDirectories);
 
                 // Add pyrevitlib/ and site-packages/ paths if pyRevitRoot is valid
                 if (!string.IsNullOrEmpty(_pyRevitRoot))

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/HookManager.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/HookManager.cs
@@ -166,19 +166,7 @@ namespace pyRevitAssemblyBuilder.SessionManager
             if (Directory.Exists(extBin))
                 paths.Add(extBin);
 
-            // Library packages live at the .lib root; nested lib/ when present.
-            if (libraryExtensions != null)
-            {
-                foreach (var libExt in libraryExtensions)
-                {
-                    if (string.IsNullOrEmpty(libExt.Directory))
-                        continue;
-                    paths.Add(libExt.Directory);
-                    var libExtLib = Path.Combine(libExt.Directory, "lib");
-                    if (Directory.Exists(libExtLib))
-                        paths.Add(libExtLib);
-                }
-            }
+            paths.AddRange(LibraryExtensionSearchPaths.Collect(libraryExtensions));
 
             // Core pyRevit paths (pyrevitlib + site-packages)
             if (!string.IsNullOrEmpty(pyRevitRoot))

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/HookManager.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/HookManager.cs
@@ -145,8 +145,9 @@ namespace pyRevitAssemblyBuilder.SessionManager
 
         /// <summary>
         /// Builds search paths for hook script execution.
-        /// Matches Python hooks.register_hooks() which passes extension.module_paths.
-        /// module_paths = [extension.lib/, extension.bin/] + library extension lib/ paths.
+        /// Matches Python hooks.register_hooks() which passes extension.module_paths:
+        /// own lib/ and bin/, each library-extension root (and nested lib/ if present),
+        /// then pyrevitlib and site-packages.
         /// </summary>
         internal string[] BuildHookSearchPaths(
             ParsedExtension extension,
@@ -165,11 +166,14 @@ namespace pyRevitAssemblyBuilder.SessionManager
             if (Directory.Exists(extBin))
                 paths.Add(extBin);
 
-            // Library extensions' lib/ directories
+            // Library packages live at the .lib root; nested lib/ when present.
             if (libraryExtensions != null)
             {
                 foreach (var libExt in libraryExtensions)
                 {
+                    if (string.IsNullOrEmpty(libExt.Directory))
+                        continue;
+                    paths.Add(libExt.Directory);
                     var libExtLib = Path.Combine(libExt.Directory, "lib");
                     if (Directory.Exists(libExtLib))
                         paths.Add(libExtLib);

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/IHookManager.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/IHookManager.cs
@@ -18,7 +18,7 @@ namespace pyRevitAssemblyBuilder.SessionManager
         /// a redundant full extension re-parse.
         /// </summary>
         /// <param name="extension">The extension to register hooks for.</param>
-        /// <param name="libraryExtensions">Library extensions whose lib/ paths are added to hook search paths.</param>
+        /// <param name="libraryExtensions">Library extensions whose directories (and nested lib/ if present) are added to hook search paths.</param>
         /// <param name="runtimeAssembly">The loaded pyRevit Runtime assembly for reflection calls.</param>
         /// <param name="pyRevitRoot">Root directory of the pyRevit installation (for pyrevitlib + site-packages paths).</param>
         void RegisterHooks(

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/LibraryExtensionSearchPaths.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/LibraryExtensionSearchPaths.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.IO;
+using pyRevitExtensionParser;
+
+namespace pyRevitAssemblyBuilder.SessionManager
+{
+    /// <summary>
+    /// Search paths for type:lib extensions. Packages live at the .lib root
+    /// (Foo.lib/Pkg); nested Foo.lib/lib/ is optional compatibility only.
+    /// </summary>
+    internal static class LibraryExtensionSearchPaths
+    {
+        /// <summary>
+        /// Returns each library-extension directory, then nested lib/ when it exists.
+        /// Used by startup, hooks, and command-type generation so the three
+        /// runtimes cannot drift. Also hashed into the rocket-mode cache key so
+        /// adding or removing a .lib (or its nested lib/) rebuilds command assemblies.
+        /// </summary>
+        public static List<string> Collect(IEnumerable<ParsedExtension> libraryExtensions)
+        {
+            var paths = new List<string>();
+            if (libraryExtensions == null)
+                return paths;
+
+            foreach (var libExt in libraryExtensions)
+            {
+                if (string.IsNullOrEmpty(libExt?.Directory))
+                    continue;
+                paths.Add(libExt.Directory);
+                var nestedLib = Path.Combine(libExt.Directory, "lib");
+                if (Directory.Exists(nestedLib))
+                    paths.Add(nestedLib);
+            }
+
+            return paths;
+        }
+
+        /// <summary>
+        /// Stable fragment for the command-assembly cache seed.
+        /// </summary>
+        public static string CacheSeed(IEnumerable<ParsedExtension> libraryExtensions)
+        {
+            return string.Join(";", Collect(libraryExtensions));
+        }
+    }
+}

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/LibraryExtensionSearchPaths.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/SessionManager/LibraryExtensionSearchPaths.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using pyRevitExtensionParser;
@@ -36,11 +37,14 @@ namespace pyRevitAssemblyBuilder.SessionManager
         }
 
         /// <summary>
-        /// Stable fragment for the command-assembly cache seed.
+        /// Order-stable fragment for the command-assembly cache seed.
+        /// Sorted so enumeration order of library extensions cannot miss the cache.
         /// </summary>
         public static string CacheSeed(IEnumerable<ParsedExtension> libraryExtensions)
         {
-            return string.Join(";", Collect(libraryExtensions));
+            var paths = Collect(libraryExtensions);
+            paths.Sort(StringComparer.OrdinalIgnoreCase);
+            return string.Join(";", paths);
         }
     }
 }

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/UIManager/SessionManagerService.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/UIManager/SessionManagerService.cs
@@ -43,7 +43,7 @@ namespace pyRevitAssemblyBuilder.SessionManager
         /// when present) so startup scripts can import packages that live at the
         /// .lib root. Populated once in LoadSession().
         /// </summary>
-        private List<string> _precomputedLibraryLibPaths = new List<string>();
+        private List<string> _precomputedLibrarySearchPaths = new List<string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SessionManagerService"/> class.
@@ -153,8 +153,8 @@ namespace pyRevitAssemblyBuilder.SessionManager
                 _logger.Debug($"[PERF]   parse '{name}': {elapsedMs}ms");
             }
 
-            _precomputedLibraryLibPaths = LibraryExtensionSearchPaths.Collect(libraryExtensions);
-            _logger.Debug($"Pre-computed {_precomputedLibraryLibPaths.Count} library lib paths");
+            _precomputedLibrarySearchPaths = LibraryExtensionSearchPaths.Collect(libraryExtensions);
+            _logger.Debug($"Pre-computed {_precomputedLibrarySearchPaths.Count} library search paths");
             
             // Get UI extensions
             stepStopwatch.Restart();
@@ -678,9 +678,9 @@ namespace pyRevitAssemblyBuilder.SessionManager
                 searchPaths.Insert(0, extLibPath);
             }
             
-            // Use pre-computed library extension lib paths (avoids N*lib_count Directory.Exists calls)
+            // Use pre-computed library-extension search paths (avoids N*lib_count Directory.Exists calls)
             // This is an optimization for #3268 - previously this loop was inside the foreach for each UI extension
-            searchPaths.AddRange(_precomputedLibraryLibPaths);
+            searchPaths.AddRange(_precomputedLibrarySearchPaths);
             
             // Add core pyRevit paths (pyrevitlib + site-packages) by discovering repo root
             // Cache the root lookup - it's the same for all extensions

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/UIManager/SessionManagerService.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/UIManager/SessionManagerService.cs
@@ -39,8 +39,9 @@ namespace pyRevitAssemblyBuilder.SessionManager
         private Dictionary<string, bool> _directoryExistsCache = new Dictionary<string, bool>();
 
         /// <summary>
-        /// Pre-materialized library extension lib paths to avoid repeated Directory.Exists checks
-        /// per extension. Populated once in LoadSession() after libraryExtensions are retrieved.
+        /// Pre-materialized library-extension search paths (root plus nested lib/
+        /// when present) so startup scripts can import packages that live at the
+        /// .lib root. Populated once in LoadSession().
         /// </summary>
         private List<string> _precomputedLibraryLibPaths = new List<string>();
 
@@ -152,16 +153,17 @@ namespace pyRevitAssemblyBuilder.SessionManager
                 _logger.Debug($"[PERF]   parse '{name}': {elapsedMs}ms");
             }
 
-            // Pre-compute library extension lib paths once to avoid N*lib_count Directory.Exists checks
-            // in BuildSearchPaths() for each UI extension. Optimization for #3268.
+            // Library packages live at the .lib root (Foo.lib/Pkg), not only
+            // under a nested lib/. Include nested lib/ when a bundle uses one.
             _precomputedLibraryLibPaths.Clear();
             foreach (var libExt in libraryExtensions)
             {
-                var libLibPath = System.IO.Path.Combine(libExt.Directory, "lib");
-                if (System.IO.Directory.Exists(libLibPath))
-                {
-                    _precomputedLibraryLibPaths.Add(libLibPath);
-                }
+                if (string.IsNullOrEmpty(libExt.Directory))
+                    continue;
+                _precomputedLibraryLibPaths.Add(libExt.Directory);
+                var nestedLib = System.IO.Path.Combine(libExt.Directory, "lib");
+                if (System.IO.Directory.Exists(nestedLib))
+                    _precomputedLibraryLibPaths.Add(nestedLib);
             }
             _logger.Debug($"Pre-computed {_precomputedLibraryLibPaths.Count} library lib paths");
             

--- a/dev/pyRevitLoader/pyRevitAssemblyBuilder/UIManager/SessionManagerService.cs
+++ b/dev/pyRevitLoader/pyRevitAssemblyBuilder/UIManager/SessionManagerService.cs
@@ -153,18 +153,7 @@ namespace pyRevitAssemblyBuilder.SessionManager
                 _logger.Debug($"[PERF]   parse '{name}': {elapsedMs}ms");
             }
 
-            // Library packages live at the .lib root (Foo.lib/Pkg), not only
-            // under a nested lib/. Include nested lib/ when a bundle uses one.
-            _precomputedLibraryLibPaths.Clear();
-            foreach (var libExt in libraryExtensions)
-            {
-                if (string.IsNullOrEmpty(libExt.Directory))
-                    continue;
-                _precomputedLibraryLibPaths.Add(libExt.Directory);
-                var nestedLib = System.IO.Path.Combine(libExt.Directory, "lib");
-                if (System.IO.Directory.Exists(nestedLib))
-                    _precomputedLibraryLibPaths.Add(nestedLib);
-            }
+            _precomputedLibraryLibPaths = LibraryExtensionSearchPaths.Collect(libraryExtensions);
             _logger.Debug($"Pre-computed {_precomputedLibraryLibPaths.Count} library lib paths");
             
             // Get UI extensions

--- a/dev/pyRevitLoader/pyRevitExtensionParserTester/HookManagerTests.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParserTester/HookManagerTests.cs
@@ -82,10 +82,9 @@ namespace pyRevitExtensionParserTester
         }
 
         // -------------------------------------------------------------------------
-        // BuildHookSearchPaths — current C# behavior (per-extension lib/bin, each
-        // library extension's lib/ if present, pyrevitlib + site-packages).
-        // Python extensionmgr also adds library extension *root* to module_paths;
-        // hook tests here intentionally assert C# HookManager only.
+        // BuildHookSearchPaths — own lib/bin, each library-extension root (and
+        // nested lib/ if present), then pyrevitlib + site-packages.
+        // Matches Python extensionmgr adding lib_ext.directory to module_paths.
         // -------------------------------------------------------------------------
 
         [Test]
@@ -122,7 +121,9 @@ namespace pyRevitExtensionParserTester
             {
                 Path.GetFullPath(Path.Combine(extDir, "lib")),
                 Path.GetFullPath(Path.Combine(extDir, "bin")),
+                Path.GetFullPath(libWithLib),
                 Path.GetFullPath(libWithLibLib),
+                Path.GetFullPath(libWithoutLib),
                 Path.GetFullPath(pyrevitlib),
                 Path.GetFullPath(sitePackages)
             };

--- a/dev/pyRevitLoader/pyRevitExtensionParserTester/LibraryExtensionSearchPathTests.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParserTester/LibraryExtensionSearchPathTests.cs
@@ -82,6 +82,22 @@ namespace pyRevitExtensionParserTester
         }
 
         [Test]
+        public void CacheSeed_SameLibrariesDifferentOrder_AreEqual()
+        {
+            var libA = CreateSubDirectory("A.lib");
+            var libB = CreateSubDirectory("Z.lib");
+            Directory.CreateDirectory(Path.Combine(libB, "lib"));
+
+            var a = new ParsedExtension { Directory = libA };
+            var b = new ParsedExtension { Directory = libB };
+
+            var forward = LibraryExtensionSearchPaths.CacheSeed(new[] { a, b });
+            var reverse = LibraryExtensionSearchPaths.CacheSeed(new[] { b, a });
+
+            Assert.AreEqual(forward, reverse);
+        }
+
+        [Test]
         public void Collect_NullLibraryExtensions_ReturnsEmpty()
         {
             CollectionAssert.IsEmpty(LibraryExtensionSearchPaths.Collect(null!));

--- a/dev/pyRevitLoader/pyRevitExtensionParserTester/LibraryExtensionSearchPathTests.cs
+++ b/dev/pyRevitLoader/pyRevitExtensionParserTester/LibraryExtensionSearchPathTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using pyRevitAssemblyBuilder.AssemblyMaker;
+using pyRevitAssemblyBuilder.SessionManager;
+using pyRevitExtensionParser;
+using pyRevitExtensionParserTest.TestHelpers;
+using static pyRevitExtensionParser.ExtensionParser;
+
+namespace pyRevitExtensionParserTester
+{
+    [TestFixture]
+    public class LibraryExtensionSearchPathTests : TempFileTestBase
+    {
+        [Test]
+        public void Collect_IncludesRootAndNestedLibWhenPresent()
+        {
+            var libRoot = CreateSubDirectory("DummyLib.lib");
+            var nested = Path.Combine(libRoot, "lib");
+            Directory.CreateDirectory(nested);
+
+            var paths = LibraryExtensionSearchPaths.Collect(new[]
+            {
+                new ParsedExtension { Directory = libRoot }
+            });
+
+            CollectionAssert.AreEqual(
+                new[] { libRoot, nested }.Select(Path.GetFullPath),
+                paths.Select(Path.GetFullPath));
+        }
+
+        [Test]
+        public void Collect_RootOnlyWhenNestedLibMissing()
+        {
+            var libRoot = CreateSubDirectory("DummyLib.lib");
+
+            var paths = LibraryExtensionSearchPaths.Collect(new[]
+            {
+                new ParsedExtension { Directory = libRoot }
+            });
+
+            CollectionAssert.AreEqual(new[] { libRoot }, paths);
+        }
+
+        [Test]
+        public void CacheSeed_ChangesWhenNestedLibAppears()
+        {
+            var libRoot = CreateSubDirectory("DummyLib.lib");
+            var libs = new List<ParsedExtension>
+            {
+                new ParsedExtension { Directory = libRoot }
+            };
+
+            var before = LibraryExtensionSearchPaths.CacheSeed(libs);
+            Directory.CreateDirectory(Path.Combine(libRoot, "lib"));
+            var after = LibraryExtensionSearchPaths.CacheSeed(libs);
+
+            Assert.AreNotEqual(before, after);
+            StringAssert.Contains(Path.Combine(libRoot, "lib"), after);
+        }
+
+        [Test]
+        public void GenerateExtensionCode_BakesRootAndNestedLibIntoSearchPaths()
+        {
+            CreateSubDirectory("DummyUi.extension/Dummy.tab/Smoke.panel/Check.pushbutton");
+            CreateFile("DummyUi.extension/Dummy.tab/Smoke.panel/Check.pushbutton/script.py", "print(1)");
+
+            var libRoot = CreateSubDirectory("DummyLib.lib");
+            var nested = Path.Combine(libRoot, "lib");
+            Directory.CreateDirectory(nested);
+
+            var uiDir = Path.Combine(TestTempDir, "DummyUi.extension");
+            var ui = ParseInstalledExtensions(new[] { uiDir }).First();
+            var libs = new[] { new ParsedExtension { Directory = libRoot, Name = "DummyLib" } };
+
+            var code = new RoslynCommandTypeGenerator(new MockPythonLogger())
+                .GenerateExtensionCode(ui, "2024", libs);
+
+            StringAssert.Contains(libRoot, code);
+            StringAssert.Contains(nested, code);
+        }
+
+        [Test]
+        public void Collect_NullLibraryExtensions_ReturnsEmpty()
+        {
+            CollectionAssert.IsEmpty(LibraryExtensionSearchPaths.Collect(null!));
+            Assert.AreEqual(string.Empty, LibraryExtensionSearchPaths.CacheSeed(null!));
+        }
+    }
+}

--- a/dev/pyRevitLoader/pyRevitExtensionParserTester/pyRevitExtensionParserTest.csproj
+++ b/dev/pyRevitLoader/pyRevitExtensionParserTester/pyRevitExtensionParserTest.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ExtensionAuthUsersTests.cs" />
     <Compile Include="AssemblyBuilderServiceTests.cs" />
     <Compile Include="HookManagerTests.cs" />
+    <Compile Include="LibraryExtensionSearchPathTests.cs" />
     <Compile Include="SessionManagerIntegrationTests.cs" />
     <Compile Include="PythonScriptMultiLangTest.cs" />
     <Compile Include="ComboBoxTests.cs" />


### PR DESCRIPTION
# Put library-extension roots on startup, hook, and command search paths

## Description

Python `extensionmgr` adds each library extension's directory (`Foo.lib/`) to `sys.path`. C# `new_loader` did not: startup and hooks only got nested `Foo.lib/lib/`, so packages at the `.lib` root (`Foo.lib/Pkg`) were invisible to `startup.py` and hooks. Command assemblies already had the root (Python-parity) but not nested `lib/`.

This PR uses one helper for startup, hooks, and command-type generation: add the `.lib` root, then nested `lib/` when it exists. Nested `lib/` is compatibility with the old C# startup search path, not Python-parity. A normal `Foo.lib/Pkg` layout is unchanged (`Directory.Exists` on nested `lib/`).

Rocket-mode cache was keyed on assembly version only (`3.4.2.0`). Command search paths are compiled into those assemblies, so enabling a new `.lib` or changing this generator did not rebuild them. The cache seed now includes the library-extension paths and a `CommandTypeGeneratorSchema` (`lib-root-1`). Bump the schema when codegen changes without a pyRevit version bump. DLL write time is still not hashed (that recompiled every extension on every rebuild).

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [ ] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- N/A (no linked issue)

---

## Additional Notes

C# only — PEP 8 / Black do not apply. No Python `module_paths` change; the C# orchestrator owns startup and hooks after the entry-module refactor.

Tests: `LibraryExtensionSearchPathTests` + `HookManagerTests.BuildHookSearchPaths`.

Rocket-mode users pick this up on next Revit start (new command-assembly hash). No manual cache delete.

---

Thank you for contributing to pyRevit! 🎉