### PR TITLE
Register TramTools extension

### DIFF
--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -375,7 +375,7 @@
             "type": "extension",
             "rocket_mode_compatible": "False",
             "name": "TramTools",
-            "description": "Free Revit productivity tools for Revit 2022-2027. No account required; anonymous usage telemetry is publicly documented.",
+            "description": "Free Revit productivity tools for Revit 2022-2027. No account, subscription, usage limit, or usage data collection.",
             "author": "Nguyen Duc Tram",
             "author_profile": "https://www.linkedin.com/in/tramnguyenduc/",
             "url": "https://github.com/ndtramk19bk-tech/TramTools.git",

--- a/extensions/extensions.json
+++ b/extensions/extensions.json
@@ -369,6 +369,19 @@
             "website": "https://github.com/lewismconte/groundit",
             "image": "",
             "dependencies": []
+        },
+        {
+            "builtin": "False",
+            "type": "extension",
+            "rocket_mode_compatible": "False",
+            "name": "TramTools",
+            "description": "Free Revit productivity tools for Revit 2022-2027. No account required; anonymous usage telemetry is publicly documented.",
+            "author": "Nguyen Duc Tram",
+            "author_profile": "https://www.linkedin.com/in/tramnguyenduc/",
+            "url": "https://github.com/ndtramk19bk-tech/TramTools.git",
+            "website": "https://github.com/ndtramk19bk-tech/TramTools",
+            "image": "",
+            "dependencies": []
         }
     ]
 }


### PR DESCRIPTION
## Description

Registers TramTools as an external pyRevit extension.

- Git URL: https://github.com/ndtramk19bk-tech/TramTools.git
- Revit compatibility: 2022-2027
- Distribution: compiled binary commands invoked by pyRevit
- Account required: No
- Usage limits: None
- Usage data collection: None

## Validation

- [x] Repository has `TramTools.tab` and `extension.json` at its root.
- [x] A fresh clone from the public Git URL passed structural validation.
- [x] 120 version-scoped invokebutton bundles were found.
- [x] No editable C# source or PDB files are distributed.
- [x] Telemetry runtime, endpoint configuration, UUID generation, and usage tracking have been removed.
- [x] No database secret or service-role key is distributed.
- [x] `extensions/extensions.json` parses as valid JSON.
- [x] `git diff --check` passes.

## Additional Notes

This pull request changes only `extensions/extensions.json`. Static packaging and Git clone validation passed. Live in-Revit testing remains required.
