### PR TITLE
fix(revit): guard TemporaryGraphicsHandlerService for pre-2022 hosts

### DIFF
--- a/pyrevitlib/pyrevit/revit/tmpgfx.py
+++ b/pyrevitlib/pyrevit/revit/tmpgfx.py
@@ -19,7 +19,7 @@ Usage::
 
 import traceback
 
-from pyrevit import DB, UI
+from pyrevit import DB, UI, HOST_APP, PyRevitException
 from pyrevit.api import ExternalService as es
 from pyrevit.framework import Guid
 from pyrevit.compat import get_elementid_value_func
@@ -29,13 +29,22 @@ get_elementid_value = get_elementid_value_func()
 
 # Internal helpers
 
+# TemporaryGraphicsHandlerService is a Revit 2022+ API member; older hosts
+# don't have it, so importing this module must not fail before any of its
+# classes are actually used.
 _BUILTIN_SERVICE = (
     es.ExternalServices.BuiltInExternalServices.TemporaryGraphicsHandlerService
+    if HOST_APP.is_newer_than(2021)
+    else None
 )
 
 
 def _get_service():
     """Return the TemporaryGraphicsHandlerService instance."""
+    if _BUILTIN_SERVICE is None:
+        raise PyRevitException(
+            "In-canvas controls (pyrevit.revit.tmpgfx) require Revit 2022 or newer."
+        )
     return es.ExternalServiceRegistry.GetService(_BUILTIN_SERVICE)
 
 


### PR DESCRIPTION
## Summary

`pyrevitlib/pyrevit/revit/tmpgfx.py` resolves `es.ExternalServices.BuiltInExternalServices.TemporaryGraphicsHandlerService` unconditionally at module import time. That enum member is a Revit 2022+ API addition and doesn't exist on Revit 2021 (and presumably older) hosts.

Since `pyrevit.revit` imports `tmpgfx` unconditionally (`pyrevitlib/pyrevit/revit/__init__.py:53`), this breaks loading of `pyrevit.revit` — and therefore every extension that transitively imports it (which is effectively all of them, directly or via `pyrevit.forms`) — on any pre-2022 Revit host, with:

```
AttributeError: 'type' object has no attribute 'TemporaryGraphicsHandlerService'
```

Introduced in 3fc87266a ("new lib and developer sample: temp graphics"), which added the in-canvas-controls feature without a host-version guard.

## Fix

Resolve `_BUILTIN_SERVICE` lazily behind `HOST_APP.is_newer_than(2021)`, falling back to `None` on older hosts. `_get_service()` now raises a clear `PyRevitException` only if something actually tries to use in-canvas controls on an unsupported host, instead of crashing at import time for every user regardless of whether they touch this feature.

## Test plan

- [x] Verified via a live Revit 2021 smoke test that `pyrevit.revit` (and every extension) now imports and loads cleanly.
- [x] `black` + `ruff check` run clean on the touched file (pre-existing D102 warnings on unrelated methods in the same file are untouched, out of scope for this fix).