### PR TITLE
Keep pyRevit.pyRevit.CLI winget publish exe-only and guard installer-…

### DIFF
--- a/build/Helpers/WingetManifestHelper.cs
+++ b/build/Helpers/WingetManifestHelper.cs
@@ -1,8 +1,151 @@
+using System.Text.Json;
+
 namespace Build.Helpers;
+
+/// <summary>
+/// The installer set currently published for a package's latest version in microsoft/winget-pkgs.
+/// </summary>
+public sealed record WingetPublishedInstallers(string LatestVersion, IReadOnlyList<string> InstallerTypes);
 
 public static class WingetManifestHelper
 {
+    private const string WingetPkgsCatalogApiUrl = "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/p/";
+
+    private const string WingetPkgsRawContentUrl = "https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests/p/";
+
     public const string ElevationProhibitedLine = "ElevationRequirement: elevationProhibited";
+
+    /// <summary>
+    /// Resolves the latest published version of <paramref name="packageId"/> in microsoft/winget-pkgs
+    /// and reads its installer types.
+    /// Returns null when the package is unpublished or the catalog cannot be reached, letting callers
+    /// fail open: wingetcreate independently rejects incompatible updates, so this lookup only exists
+    /// to turn those late failures into actionable ones.
+    /// </summary>
+    public static async Task<WingetPublishedInstallers?> GetPublishedInstallerSetAsync(
+        string packageId,
+        CancellationToken cancellationToken = default)
+    {
+        var pathSegments = string.Join('/', packageId.Split('.'));
+        using var client = CreateWingetPkgsClient();
+
+        using var listResponse = await client.GetAsync(WingetPkgsCatalogApiUrl + pathSegments, cancellationToken);
+        if (!listResponse.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var listedVersions = SelectVersionNames(await listResponse.Content.ReadAsStringAsync(cancellationToken));
+        var latestVersion = SelectLatestVersion(listedVersions);
+        if (latestVersion is null)
+        {
+            return null;
+        }
+
+        var installerManifestUrl = $"{WingetPkgsRawContentUrl}{pathSegments}/{latestVersion}/{packageId}.installer.yaml";
+        using var installerResponse = await client.GetAsync(installerManifestUrl, cancellationToken);
+        if (!installerResponse.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var installerYaml = await installerResponse.Content.ReadAsStringAsync(cancellationToken);
+        return new WingetPublishedInstallers(latestVersion, ParseInstallerTypes(installerYaml));
+    }
+
+    /// <summary>
+    /// Extracts the effective InstallerType of each entry in an installer manifest, in order.
+    /// Entries inherit the top-level InstallerType unless they declare their own.
+    /// </summary>
+    public static IReadOnlyList<string> ParseInstallerTypes(string installerYaml)
+    {
+        var types = new List<string>();
+        var topLevelType = string.Empty;
+        string? entryType = null;
+        var inInstallersSection = false;
+
+        void CloseOpenEntry()
+        {
+            if (inInstallersSection && entryType is not null)
+            {
+                types.Add(entryType);
+            }
+
+            entryType = null;
+        }
+
+        foreach (var rawLine in installerYaml.Replace("\r\n", "\n").Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(rawLine))
+            {
+                continue;
+            }
+
+            var isIndented = rawLine[0] is ' ' or '\t';
+            var trimmed = rawLine.Trim();
+
+            if (trimmed.StartsWith("- "))
+            {
+                CloseOpenEntry();
+
+                if (inInstallersSection)
+                {
+                    entryType = topLevelType;
+                }
+
+                continue;
+            }
+
+            if (!isIndented)
+            {
+                CloseOpenEntry();
+                inInstallersSection = trimmed.Equals("Installers:", StringComparison.OrdinalIgnoreCase);
+
+                if (trimmed.StartsWith("InstallerType:", StringComparison.OrdinalIgnoreCase))
+                {
+                    topLevelType = ExtractYamlScalar(trimmed);
+                }
+
+                continue;
+            }
+
+            if (inInstallersSection && trimmed.StartsWith("InstallerType:", StringComparison.OrdinalIgnoreCase))
+            {
+                entryType = ExtractYamlScalar(trimmed);
+            }
+        }
+
+        CloseOpenEntry();
+
+        return types;
+    }
+
+    /// <summary>
+    /// Guards against installer-set drift between this pipeline and the published winget catalog:
+    /// wingetcreate update only supports replacing installers one-for-one, so any addition or removal
+    /// of installers requires a baseline migration PR against microsoft/winget-pkgs first.
+    /// Note: equal-count-but-different-types mismatches (e.g. exe swapped for msi) pass this guard and
+    /// are rejected later by wingetcreate itself during URL matching.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the installer counts differ.</exception>
+    public static void EnsureCompatibleInstallerCount(
+        WingetPublishedInstallers published,
+        int intendedInstallerCount,
+        string packageId)
+    {
+        if (published.InstallerTypes.Count == intendedInstallerCount)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"WinGet baseline mismatch for {packageId}: the latest published version "
+            + $"{published.LatestVersion} in microsoft/winget-pkgs contains {published.InstallerTypes.Count} "
+            + $"installer(s) [{string.Join(", ", published.InstallerTypes)}] but this pipeline intends to submit "
+            + $"{intendedInstallerCount}. wingetcreate update cannot add or remove installers. "
+            + $"Submit a baseline migration PR that publishes the intended installer set for "
+            + $"{published.LatestVersion} (or adds a new version with it), merge it, then re-run.");
+    }
 
     public static string FindVersionManifestDirectory(string outputDir, string packageId, string version)
     {
@@ -41,4 +184,65 @@ public static class WingetManifestHelper
 
     private static bool IsElevationProhibitedLine(string line) =>
         string.Equals(line.Trim(), ElevationProhibitedLine, StringComparison.OrdinalIgnoreCase);
+
+    private static HttpClient CreateWingetPkgsClient()
+    {
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("pyrevit-build");
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        return client;
+    }
+
+    private static IReadOnlyList<string> SelectVersionNames(string catalogJson)
+    {
+        using var document = JsonDocument.Parse(catalogJson);
+        var versionNames = new List<string>();
+
+        foreach (var entry in document.RootElement.EnumerateArray())
+        {
+            if (entry.GetProperty("type").GetString() != "dir")
+            {
+                continue;
+            }
+
+            var name = entry.GetProperty("name").GetString();
+            if (name is not null && Version.TryParse(name, out _))
+            {
+                versionNames.Add(name);
+            }
+        }
+
+        return versionNames;
+    }
+
+    /// <summary>
+    /// Returns the highest version among manifest folder names; names that are not versions are ignored.
+    /// Returns null when no name is a version.
+    /// </summary>
+    public static string? SelectLatestVersion(IReadOnlyList<string> versionNames)
+    {
+        string? latestName = null;
+        Version? latestVersion = null;
+
+        foreach (var name in versionNames)
+        {
+            if (!Version.TryParse(name, out var version))
+            {
+                continue;
+            }
+
+            if (latestVersion is null || version > latestVersion)
+            {
+                latestVersion = version;
+                latestName = name;
+            }
+        }
+
+        return latestName;
+    }
+
+    private static string ExtractYamlScalar(string line)
+    {
+        return line.Substring(line.IndexOf(':') + 1).Trim().Trim('"', '\'');
+    }
 }

--- a/build/Modules/PublishWingetModule.cs
+++ b/build/Modules/PublishWingetModule.cs
@@ -31,8 +31,11 @@ public sealed class PublishWingetModule(IOptions<PublishOptions> publishOptions)
         var outputDir = Path.Combine(Path.GetTempPath(), "pyrevit-winget-manifests");
         Directory.CreateDirectory(outputDir);
 
-        var pyRevitUrls = BuildPyRevitUrls(versionInfo, releaseTag);
-        var cliUrls = BuildCliUrls(versionInfo, releaseTag);
+        var pyRevitUrls = BuildPyRevitUrls(versionInfo, releaseTag).ToArray();
+        var cliUrls = BuildCliUrls(versionInfo, releaseTag).ToArray();
+
+        await EnsurePublishedBaselineSupportsAsync("pyRevit.pyRevit", pyRevitUrls.Length, cancellationToken);
+        await EnsurePublishedBaselineSupportsAsync("pyRevit.pyRevit.CLI", cliUrls.Length, cancellationToken);
 
         await PublishPackageAsync(
             context,
@@ -159,6 +162,20 @@ public sealed class PublishWingetModule(IOptions<PublishOptions> publishOptions)
             cancellationToken: cancellationToken);
     }
 
+    private static async Task EnsurePublishedBaselineSupportsAsync(
+        string packageId,
+        int installerCount,
+        CancellationToken cancellationToken)
+    {
+        var published = await WingetManifestHelper.GetPublishedInstallerSetAsync(packageId, cancellationToken);
+        if (published is null)
+        {
+            return;
+        }
+
+        WingetManifestHelper.EnsureCompatibleInstallerCount(published, installerCount, packageId);
+    }
+
     private static IEnumerable<string> BuildPyRevitUrls(VersionInfo versionInfo, string releaseTag)
     {
         var baseUrl = $"https://github.com/pyrevitlabs/pyRevit/releases/download/{releaseTag}/";
@@ -169,7 +186,6 @@ public sealed class PublishWingetModule(IOptions<PublishOptions> publishOptions)
     {
         var baseUrl = $"https://github.com/pyrevitlabs/pyRevit/releases/download/{releaseTag}/";
         yield return $"{baseUrl}pyRevit_CLI_{versionInfo.InstallVersion}_admin_signed.exe|x64|machine";
-        yield return $"{baseUrl}pyRevit_CLI_{versionInfo.InstallVersion}_admin_signed.msi|x64|machine";
     }
 
 }

--- a/build/tests/WingetManifestHelperTests.cs
+++ b/build/tests/WingetManifestHelperTests.cs
@@ -77,4 +77,84 @@ public sealed class WingetManifestHelperTests
 
         Directory.Delete(root, recursive: true);
     }
+
+    [TestMethod]
+    public void ParseInstallerTypes_usesTopLevelTypeForEntriesWithoutOwnType()
+    {
+        var yaml = string.Join(
+            "\n",
+            "PackageIdentifier: pyRevit.pyRevit.CLI",
+            "InstallerType: inno",
+            "Scope: machine",
+            "Commands:",
+            "- pyrevit",
+            "- pyrevit-doctor",
+            "Installers:",
+            "- Architecture: x64",
+            "  InstallerUrl: https://example.com/setup.exe",
+            "  InstallerSha256: ABC",
+            "ManifestType: installer",
+            "");
+
+        var types = WingetManifestHelper.ParseInstallerTypes(yaml);
+
+        CollectionAssert.AreEqual(new[] { "inno" }, types.ToArray());
+    }
+
+    [TestMethod]
+    public void ParseInstallerTypes_readsExplicitTypesFromEachMultiInstallerEntry()
+    {
+        var yaml = string.Join(
+            "\n",
+            "PackageIdentifier: pyRevit.pyRevit.CLI",
+            "Scope: machine",
+            "Commands:",
+            "- pyrevit",
+            "Installers:",
+            "- Architecture: x64",
+            "  InstallerType: inno",
+            "  InstallerUrl: https://example.com/setup.exe",
+            "  InstallerSha256: ABC",
+            "- Architecture: x64",
+            "  InstallerType: wix",
+            "  InstallerUrl: https://example.com/setup.msi",
+            "  InstallerSha256: DEF",
+            "ManifestType: installer",
+            "");
+
+        var types = WingetManifestHelper.ParseInstallerTypes(yaml);
+
+        CollectionAssert.AreEqual(new[] { "inno", "wix" }, types.ToArray());
+    }
+
+    [TestMethod]
+    public void SelectLatestVersion_picksHighestVersionAndIgnoresNonVersionFolders()
+    {
+        var latest = WingetManifestHelper.SelectLatestVersion(["6.5.4.26228", "not-a-version", "6.10.0", "6.9.1"]);
+
+        Assert.AreEqual("6.10.0", latest);
+    }
+
+    [TestMethod]
+    public void EnsureCompatibleInstallerCount_passesWhenCountsMatch()
+    {
+        var published = new WingetPublishedInstallers("6.5.5.26237", ["inno", "wix"]);
+
+        WingetManifestHelper.EnsureCompatibleInstallerCount(published, 2, "pyRevit.pyRevit.CLI");
+    }
+
+    [TestMethod]
+    public void EnsureCompatibleInstallerCount_throwsWithRunbookWhenCountsDiffer()
+    {
+        var published = new WingetPublishedInstallers("6.5.4.26228", ["inno"]);
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => WingetManifestHelper.EnsureCompatibleInstallerCount(published, 2, "pyRevit.pyRevit.CLI"));
+
+        StringAssert.Contains(exception.Message, "pyRevit.pyRevit.CLI");
+        StringAssert.Contains(exception.Message, "6.5.4.26228");
+        StringAssert.Contains(exception.Message, "1 installer(s)");
+        StringAssert.Contains(exception.Message, "2");
+        StringAssert.Contains(exception.Message, "baseline migration PR");
+    }
 }


### PR DESCRIPTION
…set drift

wingetcreate update cannot change the installer count/types vs the latest published manifest, which broke the winget job when an msi URL was added for the CLI package (6.5.5 never reached winget).

- Revert BuildCliUrls to the exe-only installer set matching the published 6.5.4.26228 baseline so updates pass again with no upstream migration PR.
- Add a preflight check that resolves the latest published installers from microsoft/winget-pkgs for both packages before anything is submitted and fails fast with a remediation message when the sets diverge. Fails open on catalog errors since wingetcreate remains the final authority.


> opencode-ox-alpha