### PR TITLE
fix: Python Shell missing site builtins, hardcoded engine version, and toolbar placement

### DIFF
--- a/dev/pyRevitLabs.PyRevit.Shell/ShellLauncher.cs
+++ b/dev/pyRevitLabs.PyRevit.Shell/ShellLauncher.cs
@@ -106,6 +106,7 @@ namespace PyRevitLabs.PyRevit.Shell {
                 RunEngineSetupOnMainThread(host, uiapp, searchPaths, mainDispatcher);
                 host.Console.ScriptScope.SetVariable("__window__", window);
                 EnsureInteractiveBuiltins(host.Engine, host.Console.ScriptScope);
+                EnsureSiteBuiltins(host.Engine, host.Console.ScriptScope);
             });
         }
 
@@ -152,6 +153,7 @@ namespace PyRevitLabs.PyRevit.Shell {
                 RunEngineSetupOnMainThread(host, uiapp, searchPaths, mainDispatcher);
                 host.Console.ScriptScope.SetVariable("__window__", gui);
                 EnsureInteractiveBuiltins(host.Engine, host.Console.ScriptScope);
+                EnsureSiteBuiltins(host.Engine, host.Console.ScriptScope);
             });
         }
 
@@ -212,6 +214,26 @@ namespace PyRevitLabs.PyRevit.Shell {
             }
             catch {
                 // Missing values surface through normal console errors.
+            }
+        }
+
+        // The console banner advertises copyright/credits/license, but the host starts the
+        // engine with empty search paths, so IronPython's own site import never resolves them.
+        static void EnsureSiteBuiltins(ScriptEngine engine, ScriptScope scope) {
+            const string snippet =
+"try:\n" +
+"    copyright\n" +
+"except NameError:\n" +
+"    try:\n" +
+"        import site\n" +
+"        site.setcopyright()\n" +
+"    except Exception:\n" +
+"        pass\n";
+            try {
+                engine.Execute(snippet, scope);
+            }
+            catch {
+                // A shell without the informational banner objects is still usable.
             }
         }
 

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Python Shell.pushbutton/bundle.yaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/Python Shell.pushbutton/bundle.yaml
@@ -1,8 +1,8 @@
 title:
-  en_us: Python Shell
+  en_us: "Python\nShell"
 tooltip:
   en_us: >-
-    Open the interactive IronPython 3.4 shell. Type Python and see results immediately, with
-    syntax highlighting and CTRL+SPACE autocompletion. Shift+Click to choose how it opens
-    (modal, modeless, or docked).
+    Open the interactive IronPython shell running on the engine pyRevit is currently loaded
+    with. Type Python and see results immediately, with syntax highlighting and CTRL+SPACE
+    autocompletion. Shift+Click to choose how it opens (modal, modeless, or docked).
 context: zero-doc

--- a/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/bundle.yaml
+++ b/extensions/pyRevitCore.extension/pyRevit.tab/pyRevit.panel/bundle.yaml
@@ -9,11 +9,11 @@ title:
   pt_br: pyRevit
 layout:
   - tools
-  - Python Shell
   - ">>>>>"
   - About
   - Update
   - Extensions
+  - Python Shell
   - prlinks
   - rpwlinks
   - links


### PR DESCRIPTION
Fixes #3589

## `copyright` / `credits` / `license` raise `NameError`

`PythonConsoleHost.CreateRuntimeSetup()` blanks `SearchPaths` before the runtime is created, so IronPython's `PythonCommandLine.Initialize()` runs its `ImportSite()` against an empty `sys.path`. `site.setcopyright()` — which is what binds `copyright`, `credits` and `license` — therefore never runs, even though the console banner tells the user to type them. The real search paths and the embedded stdlib zip importer are only installed later, in `ConfigureEngineViaRuntime`.

(`help` resolved fine in the report because IronPython defines it natively rather than via `site`, which is what pins the diagnosis on `site`.)

`ShellLauncher.EnsureSiteBuiltins` now runs after the engine has its search paths and stdlib importer, in both the window path and the dockable-pane path:

```python
try:
    copyright
except NameError:
    try:
        import site
        site.setcopyright()
    except Exception:
        pass
```

The explicit `setcopyright()` call matters for the IPY3 engine: `python_342_lib.zip`'s `site.py` guards its `main()` behind `if not sys.flags.no_site`, while `python_2712pr_lib.zip` calls `main()` unconditionally. Calling it directly covers both forks. The outer guard makes the whole thing a no-op if `site` ever does import cleanly at startup.

## Tooltip claiming "IronPython 3.4"

The version was hardcoded, but the shell DLL ships to both the `IPY2712PR` and `IPY342` engine folders and binds to whichever fork is loaded — which is why the tooltip said 3.4 while the banner printed 2.7.12. Dropped the number rather than substituting 2.7, since the shell banner already prints the true version.

## Toolbar placement

Per the review comments on the issue, the shell is a power-user feature and the panel no longer fits comfortably at 1920x1080. Moved `Python Shell` from a top-level large button into the slideout, after `Extensions`, and split the button title onto two lines (`"Python\nShell"`, matching the existing `"Filter\nLegend"` convention).

## Testing

`dotnet build dev/pyRevitLabs.PyRevit.Shell/pyRevitLabs.PyRevit.Shell.csproj` passes for both `Release IPY2712PR` and `Release IPY342` (0 errors; only the pre-existing `Thread.Abort`/`ResetAbort` obsolescence warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)