### PR TITLE
Print Sheets: pass print settings to the internal PDF exporter and support combined export

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
@@ -54,6 +54,64 @@ EXPORT_ENCODING = 'utf_8'
 
 IS_REVIT_2022_OR_NEWER = HOST_APP.is_newer_than(2021)
 
+# Standard paper formats that PDF export is able to represent. A print
+# setting may name any size its print driver offers, so a size outside this
+# set has no equivalent and the export falls back to the sheet's own size.
+STANDARD_PAPER_FORMATS = (
+    'ANSI_A', 'ANSI_B', 'ANSI_C', 'ANSI_D', 'ANSI_E',
+    'ARCH_A', 'ARCH_B', 'ARCH_C', 'ARCH_D',
+    'ARCH_E', 'ARCH_E1', 'ARCH_E2', 'ARCH_E3',
+    'ISO_A0', 'ISO_A1', 'ISO_A2', 'ISO_A3', 'ISO_A4',
+    'ISO_B1', 'ISO_B2', 'ISO_B3', 'ISO_B4',
+    )
+
+# Driver names for sizes that do have a standard equivalent.
+PAPER_FORMAT_ALIASES = {
+    'LETTER': 'ANSI_A',
+    'TABLOID': 'ANSI_B',
+    'LEDGER': 'ANSI_B',
+    }
+
+MM_PER_INCH = 25.4
+
+# Nominal short and long edge of each standard format in millimeters, for
+# drivers that name a size by its measurements instead of by its standard.
+# Metric formats are defined in millimeters and imperial ones in inches, so
+# both are normalized here to a single unit.
+STANDARD_PAPER_SIZES_MM = {
+    'ANSI_A': (215.9, 279.4),
+    'ANSI_B': (279.4, 431.8),
+    'ANSI_C': (431.8, 558.8),
+    'ANSI_D': (558.8, 863.6),
+    'ANSI_E': (863.6, 1117.6),
+    'ARCH_A': (228.6, 304.8),
+    'ARCH_B': (304.8, 457.2),
+    'ARCH_C': (457.2, 609.6),
+    'ARCH_D': (609.6, 914.4),
+    'ARCH_E': (914.4, 1219.2),
+    'ARCH_E1': (762.0, 1066.8),
+    'ARCH_E2': (660.4, 965.2),
+    'ARCH_E3': (685.8, 990.6),
+    'ISO_A0': (841.0, 1189.0),
+    'ISO_A1': (594.0, 841.0),
+    'ISO_A2': (420.0, 594.0),
+    'ISO_A3': (297.0, 420.0),
+    'ISO_A4': (210.0, 297.0),
+    'ISO_B1': (707.0, 1000.0),
+    'ISO_B2': (500.0, 707.0),
+    'ISO_B3': (353.0, 500.0),
+    'ISO_B4': (250.0, 353.0),
+    }
+
+# Driver names round their measurements, so a match cannot demand exact
+# equality. The closest pair of standard formats differs by more than 11mm
+# on at least one edge, which this stays well inside of.
+PAPER_SIZE_TOLERANCE_MM = 3.0
+
+# Sizes already reported as unsupported, so that the warning is issued once
+# per size rather than once per sheet.
+WARNED_PAPER_SIZES = set()
+
 
 AvailableDoc = namedtuple('AvailableDoc', ['name', 'hash', 'linked'])
 
@@ -98,6 +156,95 @@ class PrintUtils:
         return dp
 
     @staticmethod
+    def paper_dimensions_mm(name):
+        """Read a paper size's measurements out of its name, in millimeters.
+
+        Print drivers routinely name a size by its measurements rather than
+        by a standard, in either inches or millimeters. Returns None when the
+        name carries no usable pair of measurements.
+        """
+        text = name.lower().replace(u'\u00d7', 'x')
+        # only a measurement pair is trustworthy; a bare number could be part
+        # of the standard's name, as in 'ARCH E1'. Drivers separate the pair
+        # with spaces or underscores, as in 'ARCH_D_(24.00_x_36.00_Inches)'.
+        found = re.search(
+            r'(\d+(?:\.\d+)?)[\s_]*x[\s_]*(\d+(?:\.\d+)?)', text)
+        if not found:
+            return None
+        width, height = float(found.group(1)), float(found.group(2))
+        if width <= 0 or height <= 0:
+            return None
+        if 'mm' in text or 'millim' in text:
+            metric = True
+        elif re.search(r'"|inch|\bin\b', text):
+            metric = False
+        else:
+            # imperial measurements stop at 48, metric ones start at 210
+            metric = max(width, height) >= 100
+        if not metric:
+            width, height = width * MM_PER_INCH, height * MM_PER_INCH
+        return min(width, height), max(width, height)
+
+    @staticmethod
+    def paper_format_name(name):
+        """Return the standard format a paper size's name refers to."""
+        key = re.sub(r'[^A-Z0-9]', '', name.upper())
+        if not key:
+            return None
+        # some drivers spell the standard out and label it a sheet, as in
+        # Microsoft's 'Architecture DSheet'
+        key = key.replace('ARCHITECTURE', 'ARCH')
+        if key.endswith('SHEET'):
+            key = key[:-len('SHEET')]
+        # aliases name their standard in full, while matching is done
+        # against names with the separator removed
+        key = PAPER_FORMAT_ALIASES.get(key, key).replace('_', '')
+        # print drivers often drop the standard's prefix, e.g. 'A1' or 'D'
+        keys = {key, 'ISO' + key, 'ANSI' + key, 'ARCH' + key}
+        for member in STANDARD_PAPER_FORMATS:
+            if member.replace('_', '') in keys:
+                return member
+        return None
+
+    @staticmethod
+    def paper_format_size(name):
+        """Return the standard format a paper size's measurements match."""
+        dims = PrintUtils.paper_dimensions_mm(name)
+        if not dims:
+            return None
+        width, height = dims
+        for member in STANDARD_PAPER_FORMATS:
+            standard = STANDARD_PAPER_SIZES_MM.get(member)
+            if standard \
+                    and abs(standard[0] - width) <= PAPER_SIZE_TOLERANCE_MM \
+                    and abs(standard[1] - height) <= PAPER_SIZE_TOLERANCE_MM:
+                return member
+        return None
+
+    @staticmethod
+    def paper_format(paper_size):
+        """Resolve a print setting's paper size to an ExportPaperFormat.
+
+        Falls back to the sheet's own size, warning once per size, when the
+        paper has no standard format that PDF export can represent.
+        """
+        name = getattr(paper_size, 'Name', None) or ''
+        # a standard name is definitive; measurements only stand in for it
+        member = PrintUtils.paper_format_name(name) \
+            or PrintUtils.paper_format_size(name)
+        if member:
+            paper_fmt = getattr(DB.ExportPaperFormat, member, None)
+            if paper_fmt is not None:
+                return paper_fmt
+        if name and name not in WARNED_PAPER_SIZES:
+            WARNED_PAPER_SIZES.add(name)
+            logger.warning(
+                'Paper size "%s" is not a standard size that PDF export can '
+                'apply; exporting at sheet size instead.', name
+                )
+        return DB.ExportPaperFormat.Default
+
+    @staticmethod
     def pdf_opts(hcb=True, hsb=True, hrp=True, hvt=True, mcl=True, print_params=None):
         opts = DB.PDFExportOptions()
         opts.HideCropBoundaries = hcb
@@ -105,6 +252,8 @@ class PrintUtils:
         opts.HideReferencePlane = hrp
         opts.HideUnreferencedViewTags = hvt
         opts.MaskCoincidentLines = mcl
+        # Without a print setting the sheet's own size is the only page size
+        # available; a variable paper setting resolves per sheet instead.
         opts.PaperFormat = DB.ExportPaperFormat.Default
         if print_params:
             try:
@@ -122,6 +271,31 @@ class PrintUtils:
                     print_params.HiddenLineViews
                     == DB.HiddenLineViewsType.RasterProcessing
                     )
+            except Exception:
+                pass
+            # Paper size, placement and zoom decide whether the page follows
+            # the print setting or collapses onto the sheet's own extents.
+            try:
+                opts.PaperFormat = \
+                    PrintUtils.paper_format(print_params.PaperSize)
+            except Exception:
+                pass
+            try:
+                opts.PaperOrientation = print_params.PageOrientation
+            except Exception:
+                pass
+            try:
+                opts.PaperPlacement = print_params.PaperPlacement
+            except Exception:
+                pass
+            try:
+                opts.OriginOffsetX = print_params.OriginOffsetX
+                opts.OriginOffsetY = print_params.OriginOffsetY
+            except Exception:
+                pass
+            try:
+                opts.ZoomType = print_params.ZoomType
+                opts.ZoomPercentage = print_params.Zoom
             except Exception:
                 pass
         return opts

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
@@ -143,6 +143,18 @@ class PrintUtils:
         return True
 
     @staticmethod
+    def export_combined_pdf(dir_path, sheet_ids, opt, doc, filename):
+        # Combine=True merges every exported sheet into a single PDF named
+        # by FileName, rather than one file per sheet.
+        opt.FileName = op.splitext(filename)[0]
+        opt.Combine = True
+        export_sheets = List[DB.ElementId]()
+        for sheet_id in sheet_ids:
+            export_sheets.Add(sheet_id)
+        doc.Export(dir_path, export_sheets, opt)
+        return True
+
+    @staticmethod
     def export_sheet_dwg(dir_path, sheet, opt, doc, filename):
         base_name = op.splitext(filename)[0]
         dwg_doc_name = base_name + ".dwg"
@@ -969,6 +981,13 @@ class PrintSheetsWindow(forms.WPFWindow):
         return True
 
     def _print_combined_sheets_in_order(self, target_sheets):
+        # The synthetic "Revit Internal Printer" is not a real print driver,
+        # so the print manager cannot combine to it. Export the ordered sheet
+        # set directly so combined output honors the print parameters.
+        if IS_REVIT_2022_OR_NEWER \
+                and self.selected_printer == "Revit Internal Printer":
+            self._export_combined_pdf_internal(target_sheets)
+            return
         # make sure we can access the print config
         print_mgr = self._get_printmanager()
         if not print_mgr:
@@ -1092,6 +1111,31 @@ class PrintSheetsWindow(forms.WPFWindow):
                         rvtsheet.SheetNumber = sheetnum
 
             self._reset_psettings()
+
+    def _export_combined_pdf_internal(self, target_sheets):
+        doc = self.selected_doc
+        dirPath = os.path.join(PrintUtils.get_dir(),
+                               PrintUtils.get_folder("_PRINT"))
+        PrintUtils.ensure_dir(dirPath)
+        PrintUtils.open_dir(dirPath)
+
+        # target_sheets already reflects the user's chosen order, including
+        # the reverse-print toggle. doc.Export honors the order of the viewIds
+        # list, so the sheets are exported as-is with no renumbering.
+        sheet_ids = [x.revit_sheet.Id for x in target_sheets if x.printable]
+        if not sheet_ids:
+            return
+
+        with revit.Transaction('Reload Keynote File', doc=doc):
+            DB.KeynoteTable.GetKeynoteTable(doc).Reload(None)
+
+        optspdf = PrintUtils.pdf_opts(
+            print_params=self.selected_print_setting.print_params)
+        try:
+            PrintUtils.export_combined_pdf(
+                dirPath, sheet_ids, optspdf, doc, "Combined Sheet Set")
+        except Exception as e:
+            logger.error('Failed to export combined PDF: %s', e)
 
     def _print_sheets_in_order(self, target_sheets):
         # make sure we can access the print config

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/Print Sheets.pushbutton/script.py
@@ -98,7 +98,7 @@ class PrintUtils:
         return dp
 
     @staticmethod
-    def pdf_opts(hcb=True, hsb=True, hrp=True, hvt=True, mcl=True):
+    def pdf_opts(hcb=True, hsb=True, hrp=True, hvt=True, mcl=True, print_params=None):
         opts = DB.PDFExportOptions()
         opts.HideCropBoundaries = hcb
         opts.HideScopeBoxes = hsb
@@ -106,6 +106,24 @@ class PrintUtils:
         opts.HideUnreferencedViewTags = hvt
         opts.MaskCoincidentLines = mcl
         opts.PaperFormat = DB.ExportPaperFormat.Default
+        if print_params:
+            try:
+                opts.ColorDepth = print_params.ColorDepth
+            except Exception:
+                pass
+            try:
+                opts.RasterQuality = print_params.RasterQuality
+            except Exception:
+                pass
+            # PDF export has no hidden line views option of its own; asking
+            # for raster processing rasterizes the whole view instead.
+            try:
+                opts.AlwaysUseRaster = (
+                    print_params.HiddenLineViews
+                    == DB.HiddenLineViewsType.RasterProcessing
+                    )
+            except Exception:
+                pass
         return opts
 
     @staticmethod
@@ -1131,7 +1149,14 @@ class PrintSheetsWindow(forms.WPFWindow):
                                                 pb1.update_progress(pbCount1, pbTotal1)
                                                 pbCount1 += 1
                                                 if IS_REVIT_2022_OR_NEWER and self.selected_printer == "Revit Internal Printer":
-                                                    optspdf = PrintUtils.pdf_opts()
+                                                    _params = (
+                                                        sheet.print_settings.PrintParameters
+                                                        if per_sheet_psettings
+                                                        else self.selected_print_setting.print_params
+                                                    )
+                                                    optspdf = PrintUtils.pdf_opts(
+                                                        print_params=_params
+                                                    )
                                                     PrintUtils.export_sheet_pdf(dirPath, sheet.revit_sheet, optspdf, doc, sheet.print_filename)
                                                 else:
                                                     print_mgr.SubmitPrint(sheet.revit_sheet)
@@ -1176,7 +1201,14 @@ class PrintSheetsWindow(forms.WPFWindow):
                                                 pb1.update_progress(pbCount1, pbTotal1)
                                                 pbCount1 += 1
                                                 if IS_REVIT_2022_OR_NEWER and self.selected_printer == "Revit Internal Printer":
-                                                    optspdf = PrintUtils.pdf_opts()
+                                                    _params = (
+                                                        sheet.print_settings.PrintParameters
+                                                        if per_sheet_psettings
+                                                        else self.selected_print_setting.print_params
+                                                    )
+                                                    optspdf = PrintUtils.pdf_opts(
+                                                        print_params=_params
+                                                    )
                                                     PrintUtils.export_sheet_pdf(dirPath, sheet.revit_sheet, optspdf, doc, sheet.print_filename)
                                                 else:
                                                     print_mgr.SubmitPrint(sheet.revit_sheet)
@@ -1225,7 +1257,9 @@ class PrintSheetsWindow(forms.WPFWindow):
                                         pb1.update_progress(pbCount1, pbTotal1)
                                         pbCount1 += 1
                                         if IS_REVIT_2022_OR_NEWER and self.selected_printer == "Revit Internal Printer":
-                                            optspdf = PrintUtils.pdf_opts()
+                                            optspdf = PrintUtils.pdf_opts(
+                                                print_params=self.selected_print_setting.print_params
+                                            )
                                             PrintUtils.export_sheet_pdf(dirPath, sheet.revit_sheet, optspdf, doc, sheet.print_filename)
                                         else:
                                             print_mgr.SubmitPrint(sheet.revit_sheet)


### PR DESCRIPTION
## Description

When Print Sheets exports through the built-in "Revit Internal Printer" (Revit 2022+), it builds a fixed `PDFExportOptions` and never converts the selected page setup's print options into export options. Nothing from the print setup reaches Revit's PDF exporter, so the page size does not shift to the setup's paper size (output renders at the titleblock's own dimensions, losing the white space between the sheet border and the paper edge), margins and placement are not applied, and colors appear even when the setup asks for black lines.

Selecting "Revit Internal Printer" together with **Combine into one file** also fails outright, with an error reporting that the print setting is incompatible with the printer. The error is a little misleading: the entry is a synthetic item this tool injects into the printer list rather than a real print driver, so the print manager cannot select it at all.  The single sheet path already bypasses the print manager for this case, but the combined path did not.

This pull request converts the page setup's parameters into export options, and adds combined export support for the internal exporter using the selected sheet order. `PaperSize`, `PageOrientation`, `PaperPlacement`, `OriginOffsetX`/`OriginOffsetY`, `ZoomType`, `Zoom`, `ColorDepth` and `RasterQuality` are mapped onto their `PDFExportOptions` counterparts. `PDFExportOptions` exposes no hidden line views option of its own, so a page setup asking for raster processing is mapped onto `AlwaysUseRaster`. Each assignment is applied defensively, so a parameter that a given Revit version does not expose is skipped rather than aborting the export.

### Resolving the paper size

This is the only part of the mapping that is not mechanical. `PaperSize` exposes only a `Name` and carries no dimensions, and that name comes from whichever print driver was active when the page setup was created, so it varies considerably between drivers. Please see the code comments for more info, or I'm happy to share additional information if needed.

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] (see note below) Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [ ] (see note below) Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

If applicable, link the issues resolved by this pull request:

- Resolves #2970

---

## Additional Notes

Tested in Revit 2024 and 2026 with the Revit Internal Printer selected, covering defined page setups, variable size, paper smaller than the sheet, a 50% reduction onto a half size sheet, combined output, and a non-standard paper size.

Paper size matching was also checked against the full paper lists reported by three drivers: Bluebeam PS, an Oce PlotWave 340, and Microsoft Print to PDF. All standard sizes resolve, and non-standard entries such as `ANSI_J4`, `ISO_A5`, the `BIND_*` bind margin variants, `Legal` and the envelope sizes fall through to the warning rather than being mapped to a near neighbor.

Black was not run on this file. The file is not currently Black formatted: running Black on the unmodified upstream copy rewrites about 935 lines, which would grow this pull request from roughly 250 changed lines to over 1200, with most of that unrelated to the fix. New statements that ran long were wrapped in Black's style by hand, and the remainder of the new code follows the file's existing conventions for quoting and line continuations. I am happy to reformat the file, either here or separately, if maintainers prefer.  In that case, I would request that you perform a review of the code as submitted, and after those issues are addressed I can run a pass through Black for continued review.

Five new lines still exceed 79 columns. They sit inside an existing block indented to 52 columns and consist of attribute chains that cannot be split any further, so Black's own output leaves them at 92 to 101 columns as well. Bringing them within 79 would mean extracting the body of that block into a helper method.  I'm happy to do that, but since it would lengthen and complicate the PR, I elected not to do so immediately.

While working on this issue, I noticed that the currently selected printer in Revit's print dialog affects the list of valid page sizes presented.  That's beyond the scope of this update, and I don't even know that it's actually an issue.  I just wanted to include the comment for context.