### PR TITLE
fix(routes): route server logs through mlogger and catch serve errors

### DIFF
--- a/pyrevitlib/pyrevit/routes/server/__init__.py
+++ b/pyrevitlib/pyrevit/routes/server/__init__.py
@@ -1,7 +1,7 @@
-
 # -*- coding: utf-8 -*-
 """Handles http api routing and serving with usage similar to flask."""
-#pylint: disable=import-error,invalid-name,broad-except,dangerous-default-value,missing-docstring
+
+# pylint: disable=import-error,invalid-name,broad-except,dangerous-default-value,missing-docstring
 from pyrevit import HOST_APP, PyRevitException
 from pyrevit.api import DB, UI
 from pyrevit.labs import TargetApps
@@ -11,8 +11,7 @@ from pyrevit.userconfig import user_config
 from pyrevit.loader import sessioninfo
 
 # types to be exported
-from pyrevit.routes.server.base import \
-    OK, ACCEPTED, INTERNAL_SERVER_ERROR, NO_CONTENT
+from pyrevit.routes.server.base import OK, ACCEPTED, INTERNAL_SERVER_ERROR, NO_CONTENT
 from pyrevit.routes.server.base import Request, Response
 
 from pyrevit.routes.server import serverinfo
@@ -21,11 +20,21 @@ from pyrevit.routes.server import server
 
 
 __all__ = (
-    'OK', 'ACCEPTED', 'INTERNAL_SERVER_ERROR', 'NO_CONTENT',
-    'Request', 'Response',
-    'init', 'activate_server', 'deactivate_server', 'get_active_server',
-    'make_response', 'get_routes', 'add_route', 'remove_route',
-    )
+    "OK",
+    "ACCEPTED",
+    "INTERNAL_SERVER_ERROR",
+    "NO_CONTENT",
+    "Request",
+    "Response",
+    "init",
+    "activate_server",
+    "deactivate_server",
+    "get_active_server",
+    "make_response",
+    "get_routes",
+    "add_route",
+    "remove_route",
+)
 
 
 mlogger = get_logger(__name__)
@@ -45,12 +54,9 @@ def activate_server():
     if not routes_server:
         try:
             rsinfo = serverinfo.register()
-            routes_server = \
-                server.RoutesServer(
-                    host=rsinfo.server_host,
-                    port=rsinfo.server_port
-                    )
-            routes_server.start()
+            routes_server = server.RoutesServer(
+                host=rsinfo.server_host, port=rsinfo.server_port
+            )
             envvars.set_pyrevit_env_var(envvars.ROUTES_SERVER, routes_server)
             return routes_server
         except Exception as rs_ex:

--- a/pyrevitlib/pyrevit/routes/server/server.py
+++ b/pyrevitlib/pyrevit/routes/server/server.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 import json
 import threading
+import time
 
 from pyrevit.api import UI
 from pyrevit.coreutils.logger import get_logger
@@ -65,6 +66,7 @@ class HttpRequestHandler(BaseHTTPRequestHandler):
     """HTTP Requests Handler."""
 
     def log_message(self, message_format, *args):
+        """Log request messages through pyRevit's logger."""
         mlogger.debug(
             "Routes request from %s | %s",
             self.client_address[0],
@@ -279,15 +281,17 @@ class ThreadedHttpServer(ThreadingMixIn, HTTPServer):
     allow_reuse_address = True
 
     def handle_error(self, request, client_address):
+        """Log request-handler failures with their connection context."""
         mlogger.error(
-            "Routes request failed from %s | %s",
+            "Routes request failed from %s | request=%s | %s",
             client_address,
+            request,
             traceback.format_exc(),
         )
 
     def shutdown(self):
-        self.socket.close()
         HTTPServer.shutdown(self)
+        self.socket.close()
 
 
 class RoutesServer(object):
@@ -304,6 +308,7 @@ class RoutesServer(object):
         self.server = ThreadedHttpServer((host, port), HttpRequestHandler)
         self.host = host
         self.port = port
+        self._stopping = False
         self.start()
 
     def __str__(self):
@@ -316,10 +321,15 @@ class RoutesServer(object):
         return "<RoutesServer @ http://%s:%s>" % (self.host or "0.0.0.0", self.port)
 
     def _serve_forever(self):
-        try:
-            self.server.serve_forever()
-        except Exception as server_err:
-            mlogger.error("Routes server stopped unexpectedly | %s", server_err)
+        while not self._stopping:
+            try:
+                self.server.serve_forever()
+                return
+            except Exception as server_err:
+                if self._stopping:
+                    return
+                mlogger.error("Routes server stopped unexpectedly | %s", server_err)
+                time.sleep(1)
 
     def start(self):
         self.server_thread = threading.Thread(target=self._serve_forever)
@@ -330,5 +340,6 @@ class RoutesServer(object):
         self.server_thread.join()
 
     def stop(self):
+        self._stopping = True
         self.server.shutdown()
         self.waitForThread()

--- a/pyrevitlib/pyrevit/routes/server/server.py
+++ b/pyrevitlib/pyrevit/routes/server/server.py
@@ -64,6 +64,13 @@ EVENT_HNDLR = UI.ExternalEvent.Create(REQUEST_HNDLR)
 class HttpRequestHandler(BaseHTTPRequestHandler):
     """HTTP Requests Handler."""
 
+    def log_message(self, message_format, *args):
+        mlogger.debug(
+            "Routes request from %s | %s",
+            self.client_address[0],
+            message_format % args,
+        )
+
     def _parse_api_path(self):
         url_parts = urlparse(self.path)
         if url_parts:
@@ -271,6 +278,13 @@ class ThreadedHttpServer(ThreadingMixIn, HTTPServer):
 
     allow_reuse_address = True
 
+    def handle_error(self, request, client_address):
+        mlogger.error(
+            "Routes request failed from %s | %s",
+            client_address,
+            traceback.format_exc(),
+        )
+
     def shutdown(self):
         self.socket.close()
         HTTPServer.shutdown(self)
@@ -301,8 +315,14 @@ class RoutesServer(object):
     def __repr__(self):
         return "<RoutesServer @ http://%s:%s>" % (self.host or "0.0.0.0", self.port)
 
+    def _serve_forever(self):
+        try:
+            self.server.serve_forever()
+        except Exception as server_err:
+            mlogger.error("Routes server stopped unexpectedly | %s", server_err)
+
     def start(self):
-        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread = threading.Thread(target=self._serve_forever)
         self.server_thread.daemon = True
         self.server_thread.start()
 


### PR DESCRIPTION
## Summary

Fix the routes server's duplicate serving loop and make server failures observable through pyRevit logging.

RoutesServer.__init__() already calls start(), which launches a daemon thread running HTTPServer.serve_forever(). activate_server() then called start() a second time on the same HTTPServer instance. This created two concurrent serve_forever() loops sharing one listening socket and overwrote the first thread reference, making startup and shutdown behavior unreliable.

The activation path now only constructs and registers the server, leaving its single startup in RoutesServer.__init__().

The change also routes request messages, request-handler tracebacks, and unexpected serve_forever() failures through mlogger.

## Validation

- Focused routes-server tests require the pyRevit IronPython/.NET runtime and cannot run under local CPython because the System module is unavailable.
- Ruff reports existing missing-docstring violations in this legacy module, including the two new overrides, so it is not a clean pass/fail gate for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route server stability by retrying after unexpected serving errors.
  * Ensured shutdown requests stop retrying and complete cleanly.
  * Corrected server startup behavior to prevent unintended immediate activation.
  * Improved shutdown handling by closing server connections in the proper sequence.

* **Diagnostics**
  * Enhanced error logs with additional request context to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the duplicate routes-server startup and sends request and server errors through pyRevit logging.

- Starts each `RoutesServer` only through its constructor.
- Adds request and handler-error logging through `mlogger`.
- Catches and logs unexpected `serve_forever()` failures.
- The two new public logging overrides still need the repository-required docstrings.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only the non-blocking missing docstrings needing cleanup.

The startup correction preserves the constructor's existing start behavior, and the logging paths have no supported runtime defect; only the repository documentation requirement remains unmet.

**Files Needing Attention:** pyrevitlib/pyrevit/routes/server/server.py
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pyrevitlib/pyrevit/routes/server/__init__.py | Removes the redundant second start call while preserving registration and error handling. |
| pyrevitlib/pyrevit/routes/server/server.py | Adds centralized request and serving-error logging; the new public overrides lack required docstrings. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[activate_server] --> B[Construct RoutesServer]
    B --> C[Constructor calls start once]
    C --> D[Daemon thread runs _serve_forever]
    D --> E[HTTP requests]
    E --> F[Request and handler errors logged through mlogger]
    D -->|Unexpected failure| G[Server failure logged through mlogger]
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pyrevitlabs%2Fpyrevit%22%20on%20the%20existing%20branch%20%22fix%2Froutes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Froutes%22.%0A%0AGreploop%20pyrevitlabs%2Fpyrevit%20PR%20%233620%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=pyrevitlabs%2Fpyrevit&pr=3620&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pyrevitlabs%2Fpyrevit%22%20on%20the%20existing%20branch%20%22fix%2Froutes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Froutes%22.%0A%0A%23%23%23%20Issue%201%0Apyrevitlib%2Fpyrevit%2Froutes%2Fserver%2Fserver.py%3A67%0A**Public%20overrides%20lack%20docstrings**%0A%0AThe%20new%20public%20%60log_message%60%20and%20%60handle_error%60%20overrides%20lack%20the%20Google-style%20docstrings%20required%20by%20%60AGENTS.md%60%2C%20so%20the%20configured%20documentation%20lint%20reports%20both%20methods.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=pyrevitlabs%2Fpyrevit&pr=3620&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
pyrevitlib/pyrevit/routes/server/server.py:67
**Public overrides lack docstrings**

The new public `log_message` and `handle_error` overrides lack the Google-style docstrings required by `AGENTS.md`, so the configured documentation lint reports both methods.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(routes): route server logs through m..."](https://github.com/pyrevitlabs/pyrevit/commit/1d9fef1f1c1542610ad4814c6ddd074107008b67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62305006)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/pyrevitlabs/pyrevit/blob/develop/AGENTS.md))

<!-- /greptile_comment -->