### PR TITLE
fix icon pos, fix background color for match prop

### DIFF
--- a/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard.Icons.xaml
+++ b/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard.Icons.xaml
@@ -8,10 +8,10 @@
     -->
 
     <!-- Funnel+Az: default substring/fuzzy search mode -->
-    <Canvas x:Key="filterIcon" Width="16" Height="16">
-        <Path Canvas.Top="-7" Canvas.Left="-5"
+    <Canvas x:Key="filterIcon">
+        <Path Canvas.Top="-14" Canvas.Left="-14"
               Data="F1 M 45.4403,56.9637L 45.4403,55.0463L 52.8201,44.5143L 52.8201,44.4237L 46.13,44.4237L 46.13,41.4774L 57.372,41.4774L 57.372,43.5352L 50.1532,53.9265L 50.1532,54.0174L 57.4869,54.0174L 57.4869,56.9637L 45.4403,56.9637 Z M 34.8333,61.75L 34.8333,42.75L 19,20.5833L 57,20.5833L 41.1667,42.75L 41.1667,58.5833L 34.8333,61.75 Z M 25.903,52.8055L 21.4072,52.8055L 20.289,56.9855L 16.6085,56.9855L 21.4072,41.4556L 26.0661,41.4556L 30.9337,56.9855L 27.1143,56.9855L 25.903,52.8055 Z M 21.9196,50.2801L 25.3905,50.2801L 24.4122,46.9804L 23.9987,45.4806L 23.6201,43.981L 23.5736,43.981L 23.2212,45.4941L 22.8514,47.0194L 21.9196,50.2801 Z"
-              Fill="Black">
+              Fill="{DynamicResource pyRevitIconBrush}">
             <Path.LayoutTransform>
                 <ScaleTransform ScaleX="0.36" ScaleY="0.36"/>
             </Path.LayoutTransform>
@@ -19,10 +19,10 @@
     </Canvas>
 
     <!-- Asterisk-dot: regex mode active -->
-    <Canvas x:Key="regexIcon" Width="16" Height="16">
-        <Path Canvas.Top="-6" Canvas.Left="-3"
+    <Canvas x:Key="regexIcon">
+        <Path Canvas.Top="-12" Canvas.Left="-11"
               Data="M16,16.92C15.67,16.97 15.34,17 15,17C14.66,17 14.33,16.97 14,16.92V13.41L11.5,15.89C11,15.5 10.5,15 10.11,14.5L12.59,12H9.08C9.03,11.67 9,11.34 9,11C9,10.66 9.03,10.33 9.08,10H12.59L10.11,7.5C10.3,7.25 10.5,7 10.76,6.76V6.76C11,6.5 11.25,6.3 11.5,6.11L14,8.59V5.08C14.33,5.03 14.66,5 15,5C15.34,5 15.67,5.03 16,5.08V8.59L18.5,6.11C19,6.5 19.5,7 19.89,7.5L17.41,10H20.92C20.97,10.33 21,10.66 21,11C21,11.34 20.97,11.67 20.92,12H17.41L19.89,14.5C19.7,14.75 19.5,15 19.24,15.24V15.24C19,15.5 18.75,15.7 18.5,15.89L16,13.41V16.92H16V16.92M5,19A2,2 0 0,1 7,17A2,2 0 0,1 9,19A2,2 0 0,1 7,21A2,2 0 0,1 5,19H5Z"
-              Fill="Black">
+              Fill="{DynamicResource pyRevitIconBrush}">
             <Path.LayoutTransform>
                 <ScaleTransform ScaleX="0.9" ScaleY="0.9"/>
             </Path.LayoutTransform>
@@ -58,7 +58,7 @@
     <!-- ── Styles ── -->
 
     <Style x:Key="ClearButton" TargetType="Button">
-        <Setter Property="Background" Value="White"/>
+        <Setter Property="Background" Value="{DynamicResource pyRevitControlBackgroundBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
     </Style>
 

--- a/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard.Icons.xaml
+++ b/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard.Icons.xaml
@@ -55,11 +55,4 @@
     <!-- Check-all: paste to current Revit selection -->
     <Geometry x:Key="PasteSelGeometry">M0.41,13.41L6,19L7.41,17.58L1.83,12M22.24,5.58L11.66,16.17L7.5,12L6.07,13.41L11.66,19L23.66,7M18,7L16.59,5.58L10.24,11.93L11.66,13.34L18,7Z</Geometry>
 
-    <!-- ── Styles ── -->
-
-    <Style x:Key="ClearButton" TargetType="Button">
-        <Setter Property="Background" Value="{DynamicResource pyRevitControlBackgroundBrush}"/>
-        <Setter Property="BorderThickness" Value="0"/>
-    </Style>
-
 </ResourceDictionary>

--- a/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard_content.xaml
+++ b/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard_content.xaml
@@ -33,17 +33,14 @@
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"
                         Margin="0,0,1,0"
+                        Padding="0,-4,0,0"
                         BorderThickness="0"
-                        Style="{DynamicResource ClearButton}"
+                        Background="{DynamicResource pyRevitControlBackgroundBrush}"
                         Click="clear_search">
-                    <Canvas Width="16" Height="16">
-                        <Path Canvas.Top="1" Canvas.Left="1"
+                    <Canvas Width="25" Height="25" VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <Path Canvas.Top="3" Canvas.Left="1"
                               Data="{DynamicResource CloseSearchGeometry}"
-                              Fill="DimGray">
-                            <Path.LayoutTransform>
-                                <ScaleTransform ScaleX="0.7" ScaleY="0.7"/>
-                            </Path.LayoutTransform>
-                        </Path>
+                              Fill="{DynamicResource pyRevitSubtleForegroundBrush}"/>
                     </Canvas>
                 </Button>
             </Grid>

--- a/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard_content.xaml
+++ b/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard_content.xaml
@@ -1,6 +1,6 @@
 <UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             Background="White">
+             Background="{DynamicResource pyRevitWindowBackgroundBrush}">
 
     <Grid Margin="8">
         <Grid.RowDefinitions>

--- a/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard_page.xaml
+++ b/extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard_page.xaml
@@ -1,3 +1,3 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      Background="White"/>
+      Background="{DynamicResource pyRevitWindowBackgroundBrush}"/>


### PR DESCRIPTION
## Description

introduced in theme support PR

Icon issue before after:
<img width="898" height="94" alt="image" src="https://github.com/user-attachments/assets/1806a756-8da4-4d57-83d3-9cbbc6f6f3ec" />

Color issue before after:
<img width="698" height="72" alt="image" src="https://github.com/user-attachments/assets/84ea4bbf-8554-46e6-8d08-36ad269718db" />


---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [X] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [X] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [X] Changes are tested and verified to work as expected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated clipboard pane and page backgrounds to follow the application theme.
  * Adjusted filter and regular-expression toggle icons for improved theme compatibility, sizing, and positioning.
  * Updated the clear button with theme-aware colors, a larger centered icon, and improved spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects clipboard-pane icon positioning and replaces fixed colors with dynamic theme brushes.
- Repositions the filter and regex icons and applies the themed icon brush.
- Uses themed window and control backgrounds in the clipboard views.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The current clipboard hosts provide the referenced theme resources, and the icon changes remain within the existing fixed-size toggle control.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard.Icons.xaml | Updates icon geometry and replaces fixed icon and button colors with existing theme resources. |
| extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard_content.xaml | Replaces the fixed white user-control background with the themed window background. |
| extensions/pyRevitTools.extension/lib/panes/clipboard/clipboard_page.xaml | Replaces the fixed white page background with the themed window background. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix icon pos, fix background color"](https://github.com/pyrevitlabs/pyrevit/commit/30ac3b756cbc6947503c5e2c84ed998e254a8aa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62757396)</sub>

<!-- /greptile_comment -->