### PR TITLE
Fix IPY3 startup stack overflow and Requests compatibility

### DIFF
--- a/pyrevitlib/pyrevit/compat.py
+++ b/pyrevitlib/pyrevit/compat.py
@@ -12,15 +12,15 @@ import System
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
-IRONPY = '.net' in sys.version.lower()
+IRONPY = ".net" in sys.version.lower()
 IRONPY2 = PY2 and IRONPY
 IRONPY3 = PY3 and IRONPY
 NETCORE = System.Environment.Version.Major >= 8  # Revit 2025 onwards
-NETFRAMEWORK = not NETCORE # Revit 2024 and earlier
+NETFRAMEWORK = not NETCORE  # Revit 2024 and earlier
 NO_REVIT = -1
 REVIT_NETCORE_VERSION = 2025
 
-#pylint: disable=import-error,unused-import
+# pylint: disable=import-error,unused-import
 if PY3:
     __builtins__["unicode"] = str
 
@@ -38,13 +38,11 @@ elif PY3:
     import urllib
     from urllib.parse import urlparse
 
-try:
-    if PY3:
-        import requests
-    else:
-        import pyrevit.netrequests as requests
-except Exception:
+if IRONPY:
+    import pyrevit.netrequests as requests
+else:
     import requests
+
 
 def _get_revit_version():
     """Returns the current Revit version as an integer."""
@@ -63,11 +61,11 @@ def _get_revit_version():
         return int(__revit__.ControlledApplication.VersionNumber)
 
 
-#pylint: disable=C0103
+# pylint: disable=C0103
 safe_strtype = str
 if PY2:
     # https://gist.github.com/gornostal/1f123aaf838506038710
-    safe_strtype = lambda x: unicode(x)  #pylint: disable=E0602,unnecessary-lambda
+    safe_strtype = lambda x: unicode(x)  # pylint: disable=E0602,unnecessary-lambda
 
 
 def get_elementid_value_func():
@@ -86,8 +84,10 @@ def get_elementid_value_func():
         ```
     """
     attr = "Value" if _get_revit_version() > 2023 else "IntegerValue"
+
     def from_elementid(item):
         return getattr(item, attr)
+
     return from_elementid
 
 
@@ -106,9 +106,12 @@ def get_elementid_from_value_func():
         ```
     """
     from pyrevit.api import DB
+
     cast_class = System.Int64 if _get_revit_version() > 2023 else int
+
     def from_value(value):
         return DB.ElementId(cast_class(value))
+
     return from_value
 
 

--- a/pyrevitlib/pyrevit/unittests/test_py3_compat.py
+++ b/pyrevitlib/pyrevit/unittests/test_py3_compat.py
@@ -71,6 +71,20 @@ def _import_failures(module_names):
 class ImportTests(unittest.TestCase):
     """Every supported module must be importable on the running engine."""
 
+    def test_requests_backend_matches_engine(self):
+        """IronPython uses the CLR HTTP shim; CPython uses requests."""
+        from pyrevit import compat
+
+        expected_module = "pyrevit.netrequests" if IRONPY else "requests"
+        self.assertEqual(expected_module, compat.requests.__name__)
+
+    def test_vendored_requests_imports(self):
+        """Direct requests imports remain available on every Python 3 engine."""
+        failures = _import_failures(["urllib3", "requests"])
+        self.assertEqual(
+            [], failures, "import failures:\n{}".format("\n".join(failures))
+        )
+
     def test_core_module_imports(self):
         """Core pyrevit modules import cleanly on this engine."""
         failures = _import_failures(CORE_MODULES)
@@ -84,7 +98,7 @@ class ImportTests(unittest.TestCase):
         ".NET 8 hosts — dev/libs/netcore omits them",
     )
     def test_interop_module_imports(self):
-        """interop modules import cleanly (needs the framework CLR shim)."""
+        """Interop modules import cleanly (needs the framework CLR shim)."""
         failures = _import_failures(INTEROP_MODULES)
         self.assertEqual(
             [], failures, "import failures:\n{}".format("\n".join(failures))
@@ -104,7 +118,7 @@ class ImportTests(unittest.TestCase):
         import pyRevitLabs.Json  # noqa pylint: disable=import-error,unused-import
 
     def test_interop_native_module_imports(self):
-        """interop modules that load native/external binaries (opt-in)."""
+        """Interop modules that load native/external binaries (opt-in)."""
         if not TEST_NATIVE_INTEROP:
             self.skipTest(
                 "loads native binaries into the Revit process; set "

--- a/pyrevitlib/pyrevit/unittests/test_py3_compat.py
+++ b/pyrevitlib/pyrevit/unittests/test_py3_compat.py
@@ -85,6 +85,17 @@ class ImportTests(unittest.TestCase):
             [], failures, "import failures:\n{}".format("\n".join(failures))
         )
 
+    def test_vendored_requests_wraps_invalid_json(self):
+        """Malformed JSON raises the documented Requests exception."""
+        import requests
+
+        response = requests.Response()
+        response._content = b"{"
+        response.encoding = "utf-8"
+
+        with self.assertRaises(requests.exceptions.JSONDecodeError):
+            response.json()
+
     def test_core_module_imports(self):
         """Core pyrevit modules import cleanly on this engine."""
         failures = _import_failures(CORE_MODULES)

--- a/site-packages/requests/compat.py
+++ b/site-packages/requests/compat.py
@@ -71,7 +71,10 @@ elif is_py3:
     if has_simplejson:
         from simplejson import JSONDecodeError
     else:
-        from json import JSONDecodeError
+        try:
+            from json import JSONDecodeError
+        except ImportError:
+            JSONDecodeError = ValueError
 
     builtin_str = str
     str = str

--- a/site-packages/requests/models.py
+++ b/site-packages/requests/models.py
@@ -913,6 +913,8 @@ class Response(object):
             # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
             if is_py2: # e is a ValueError
                 raise RequestsJSONDecodeError(e.message)
+            elif not all(hasattr(e, attr) for attr in ("msg", "doc", "pos")):
+                raise RequestsJSONDecodeError(str(e))
             else:
                 raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
 

--- a/site-packages/urllib3/request.py
+++ b/site-packages/urllib3/request.py
@@ -173,7 +173,7 @@ class RequestMethods(object):
         return self.urlopen(method, url, **extra_kw)
 
 
-if not six.PY2:
+if not six.PY2 and sys.implementation.name != "ironpython":
 
     class RequestModule(sys.modules[__name__].__class__):
         def __call__(self, *args, **kwargs):


### PR DESCRIPTION
## Description

Fixes a Revit 2026 process crash during IPY342 session startup.

pyrevit.compat eagerly imported vendored Requests on Python 3. urllib3 then attempted a module class reassignment unsupported by IronPython, and the fallback retried the same failing import until the process exhausted its stack before runtime logging initialized.

## Changes

- Use the CLR-backed pyrevit.netrequests backend for pyRevit internals on IronPython.
- Skip the urllib3 callable-module compatibility shim on IronPython.
- Fall back to ValueError when IPY 3.4 lacks json.JSONDecodeError.
- Add regression coverage for backend selection and direct vendored Requests imports.

## Verification

- Confirmed the original dump contained System.StackOverflowException with exception code 0xc00000fd.
- Confirmed Revit 2026 with engine 342 completes startup and initializes runtime logging.
- Confirmed Test FullFrame Engine imports Requests and performs a live HTTP request successfully.
- Ruff checks passed for maintained Python files.
- Python 3 compatibility checks passed for the affected maintained and urllib3 files.
- Python compilation and staged diff validation passed.
- Commit hooks passed.

## Additional Notes

The separate Test Persistent Engine Action failure exercises the legacy keynote external-event path and is not caused by this Requests startup issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP request compatibility across supported Python runtimes, including IronPython and CPython.
  - Resolved an IronPython-specific networking compatibility issue.
  - Improved JSON parsing compatibility when decoder support varies between runtime environments.
  - Improved handling of malformed JSON responses.
  - Added safeguards to ensure bundled networking components import correctly across Python 3 environments.

- **Tests**
  - Added coverage for runtime-specific request handling, networking imports, and malformed JSON responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents IronPython 3 startup failure by selecting the CLR HTTP backend and avoiding urllib3’s unsupported module-class reassignment. It also adds compatibility imports and regression coverage.

- Uses `pyrevit.netrequests` for IronPython.
- Disables urllib3’s callable-module shim on IronPython.
- Adds a fallback for older JSON implementations, but its interaction with `Response.json()` remains broken.
- Tests backend selection and direct vendored package imports.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The startup fix looks sound, but the invalid-JSON path in vendored Requests should be fixed before merging.

IronPython 3.4 can now import Requests, but `Response.json()` turns a normal invalid-JSON error into an `AttributeError` because the new ValueError fallback lacks the attributes consumed by the existing handler.

**Files Needing Attention:** site-packages/requests/compat.py, site-packages/requests/models.py
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pyrevitlib/pyrevit/compat.py | Selects the CLR-backed HTTP implementation on both supported IronPython versions. |
| pyrevitlib/pyrevit/unittests/test_py3_compat.py | Adds engine-specific backend and direct vendored import checks. |
| site-packages/requests/compat.py | Avoids the missing JSONDecodeError import, but leaves invalid JSON handling broken on IronPython 3.4. |
| site-packages/urllib3/request.py | Skips unsupported module-class reassignment on IronPython while preserving CPython behavior. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pyrevitlabs%2Fpyrevit%22%20on%20the%20existing%20branch%20%22fix%2Fipy3-startup-hotfix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fipy3-startup-hotfix%22.%0A%0AGreploop%20pyrevitlabs%2Fpyrevit%20PR%20%233637%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=pyrevitlabs%2Fpyrevit&pr=3637&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pyrevitlabs%2Fpyrevit%22%20on%20the%20existing%20branch%20%22fix%2Fipy3-startup-hotfix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fipy3-startup-hotfix%22.%0A%0A%23%23%23%20Issue%201%0Asite-packages%2Frequests%2Fcompat.py%3A77%0A**Invalid%20JSON%20Raises%20AttributeError**%0A%0AOn%20IronPython%203.4%2C%20invalid%20JSON%20raises%20a%20plain%20%60ValueError%60.%20This%20fallback%20catches%20it%2C%20but%20%60Response.json%28%29%60%20then%20reads%20%60e.msg%60%2C%20%60e.doc%60%2C%20and%20%60e.pos%60%2C%20which%20%60ValueError%60%20does%20not%20provide.%20Parsing%20a%20short%20invalid%20response%20therefore%20raises%20%60AttributeError%60%20instead%20of%20the%20documented%20%60requests.exceptions.JSONDecodeError%60.%20The%20fallback%20path%20must%20construct%20the%20Requests%20exception%20without%20relying%20on%20those%20missing%20attributes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=pyrevitlabs%2Fpyrevit&pr=3637&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
site-packages/requests/compat.py:77
**Invalid JSON Raises AttributeError**

On IronPython 3.4, invalid JSON raises a plain `ValueError`. This fallback catches it, but `Response.json()` then reads `e.msg`, `e.doc`, and `e.pos`, which `ValueError` does not provide. Parsing a short invalid response therefore raises `AttributeError` instead of the documented `requests.exceptions.JSONDecodeError`. The fallback path must construct the Requests exception without relying on those missing attributes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): prevent IPY3 requests star..."](https://github.com/pyrevitlabs/pyrevit/commit/172c57d6b9ae8d4858619f7d95e3526949f0e1a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63405538)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->