### PR TITLE
Filter Legend - fix counter for failures

### DIFF
--- a/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/script.py
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/script.py
@@ -282,7 +282,7 @@ with revit.TransactionGroup("Create Filter Legend(s)"):
                             f.Name,
                             src_view.Name,
                         )
-                        row_advance = row_height
+                        raise
 
                     y -= row_advance + row_spacing
 


### PR DESCRIPTION
## Description

Rollback failed filter-legend rows instead of committing partial views

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.


---

## Additional Notes

https://github.com/pyrevitlabs/pyRevit/pull/3625#discussion_r3996520332




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filter legend generation now stops processing the affected view when a filter row encounters an error, rather than continuing with an assigned row height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR re-raises filter-row processing errors so the current legend view transaction rolls back instead of committing a partial view.
- Successfully completed views remain committed.
- Failed views are excluded from success counters and reporting.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The raised exception rolls back only the failed view transaction, is caught before leaving the transaction group, and prevents failed views from incrementing success counters.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/pyRevitTools.extension/pyRevit.tab/Drawing Set.panel/views.stack/Legends.pulldown/FilterLegend.pushbutton/script.py | Re-raises row-processing failures to roll back the affected view and keep result counters accurate. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Rollback failed filter-legend rows inste..."](https://github.com/pyrevitlabs/pyrevit/commit/cfdf63907962afe59579a3e2519c7fb1c96e2300) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63579377)</sub>

<!-- /greptile_comment -->