### PR TITLE
fix dark theme for custom props panel

### DIFF
--- a/extensions/pyRevitTools.extension/lib/panes/customprops/pane.py
+++ b/extensions/pyRevitTools.extension/lib/panes/customprops/pane.py
@@ -829,12 +829,18 @@ class CustomPropertiesPanel(forms.WPFPanel):
             lbl.Text = text
             lbl.FontSize = 11
             lbl.FontWeight = framework.Windows.FontWeights.SemiBold
-            lbl.Foreground = SolidColorBrush(Color.FromArgb(255, 0x55, 0x55, 0x55))
+            lbl.SetResourceReference(
+                framework.Controls.TextBlock.ForegroundProperty,
+                "pyRevitWindowForegroundBrush",
+            )
             lbl.Margin = framework.Windows.Thickness(0, 0, 0, 3)
             panel.Children.Add(lbl)
         line = framework.Controls.Border()
         line.Height = 1
-        line.Background = SolidColorBrush(Color.FromArgb(255, 0xDD, 0xDD, 0xDD))
+        line.SetResourceReference(
+            framework.Controls.Border.BackgroundProperty,
+            "pyRevitControlBorderBrush",
+        )
         panel.Children.Add(line)
         return panel
 

--- a/extensions/pyRevitTools.extension/lib/panes/customprops/pane_ui.xaml
+++ b/extensions/pyRevitTools.extension/lib/panes/customprops/pane_ui.xaml
@@ -1,6 +1,6 @@
 <Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      Background="White">
+      Background="{DynamicResource pyRevitWindowBackgroundBrush}">
 
     <Page.Resources>
         <Style x:Key="LabelStyle" TargetType="TextBlock">
@@ -11,9 +11,9 @@
         <Style x:Key="ReadOnlyLabel" TargetType="TextBlock">
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Foreground" Value="#555555"/>
+            <Setter Property="Foreground" Value="{DynamicResource pyRevitSubtleForegroundBrush}"/>
         </Style>
-        <Style x:Key="FieldCombo" TargetType="ComboBox">
+        <Style x:Key="FieldCombo" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
             <Setter Property="IsEditable" Value="True"/>
             <Setter Property="Height" Value="22"/>
             <Setter Property="FontSize" Value="11"/>
@@ -23,17 +23,12 @@
         <Style x:Key="SectionHeader" TargetType="TextBlock">
             <Setter Property="FontWeight" Value="SemiBold"/>
             <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Foreground" Value="#333333"/>
+            <Setter Property="Foreground" Value="{DynamicResource pyRevitWindowForegroundBrush}"/>
             <Setter Property="Margin" Value="0,6,0,4"/>
-        </Style>
-        <Style x:Key="ActionButton" TargetType="Button">
-            <Setter Property="Padding" Value="10,4"/>
-            <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Margin" Value="0,6,4,0"/>
         </Style>
         <Style x:Key="Separator" TargetType="Border">
             <Setter Property="Height" Value="1"/>
-            <Setter Property="Background" Value="#DDDDDD"/>
+            <Setter Property="Background" Value="{DynamicResource pyRevitControlBorderBrush}"/>
             <Setter Property="Margin" Value="0,6,0,6"/>
         </Style>
     </Page.Resources>
@@ -55,7 +50,7 @@
                    Text="No selection"
                    FontStyle="Italic"
                    FontSize="11"
-                   Foreground="#666666"
+                   Foreground="{DynamicResource pyRevitSubtleForegroundBrush}"
                    Margin="0,0,0,4"/>
 
         <Border x:Name="fixed_params_separator"
@@ -122,7 +117,7 @@
             <Border x:Name="worksharing_separator"
                     Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
                     Height="1"
-                    Background="#DDDDDD"
+                    Background="{DynamicResource pyRevitControlBorderBrush}"
                     Margin="0,8,0,6"/>
 
             <TextBlock x:Name="worksharing_creator_lbl"
@@ -178,31 +173,33 @@
             <Button x:Name="copy_btn"
                     Grid.Column="0"
                     Content="{DynamicResource BtnCopy}"
+                    Padding="10,4"
+                    Margin="0,6,4,0"
                     Click="copy_clicked"
                     IsEnabled="False"
-                    Style="{StaticResource ActionButton}"
                     ToolTip="{DynamicResource BtnCopy.Tooltip}"/>
 
             <Button x:Name="paste_btn"
                     Grid.Column="1"
                     Content="{DynamicResource BtnPaste}"
+                    Padding="10,4"
+                    Margin="0,6,4,0"
                     Click="paste_clicked"
                     IsEnabled="False"
-                    Style="{StaticResource ActionButton}"
                     ToolTip="{DynamicResource BtnPaste.Tooltip}"/>
 
             <Button x:Name="filter_btn"
                     Grid.Column="2"
                     Content="{DynamicResource BtnFilter}"
+                    Padding="10,4"
+                    Margin="0,6,4,0"
                     Click="filter_clicked"
                     IsEnabled="False"
-                    Style="{StaticResource ActionButton}"
                     ToolTip="{DynamicResource BtnFilter.Tooltip}"/>
 
             <Button Grid.Column="4"
                     Content="{DynamicResource BtnApply}"
                     Padding="16,4"
-                    FontSize="11"
                     Margin="0,6,0,0"
                     HorizontalAlignment="Right"
                     Click="apply_clicked"/>

--- a/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/Custom Properties.smartbutton/config_ui.xaml
+++ b/extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/Custom Properties.smartbutton/config_ui.xaml
@@ -26,7 +26,7 @@
                    Text="{DynamicResource TbRestartHint}"
                    TextWrapping="Wrap"
                    FontSize="10"
-                   Foreground="#888888"
+                   Foreground="{DynamicResource pyRevitSubtleForegroundBrush}"
                    Margin="20,0,0,10"/>
 
         <CheckBox x:Name="worksharing_cb"
@@ -40,7 +40,7 @@
                    Text="{DynamicResource TbParamsHint}"
                    TextWrapping="Wrap"
                    FontSize="11"
-                   Foreground="#444444"
+                   Foreground="{DynamicResource pyRevitSubtleForegroundBrush}"
                    Margin="0,0,0,8"/>
 
         <TextBox x:Name="params_tb"
@@ -50,13 +50,13 @@
                  FontFamily="Consolas"
                  FontSize="11"
                  Padding="6"
-                 BorderBrush="#AAAAAA"/>
+                 BorderBrush="{DynamicResource pyRevitControlBorderBrush}"/>
 
         <TextBlock Grid.Row="5"
                    Text="{DynamicResource TbExamples}"
                    TextWrapping="Wrap"
                    FontSize="10"
-                   Foreground="#888888"
+                   Foreground="{DynamicResource pyRevitSubtleForegroundBrush}"
                    Margin="0,4,0,8"/>
 
         <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right">


### PR DESCRIPTION
## Description

<img width="944" height="593" alt="image" src="https://github.com/user-attachments/assets/62d6ccc9-50c2-4d00-b646-07b81be2b1bf" />

---

## Checklist

Before submitting your pull request, ensure the following requirements are met:

- [x] Code follows the [PEP 8](https://peps.python.org/pep-0008/) style guide.
- [x] Code has been formatted with [Black](https://github.com/psf/black) using the command:
  ```bash
  pipenv run black {source_file_or_directory}
  ```
- [x] Changes are tested and verified to work as expected.

---

## Related Issues

Partial #3629 



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the Custom Properties panel and configuration dialog to follow pyRevit's light and dark themes.
- Replaces fixed text, background, separator, and border colors with shared theme brushes.
- Makes editable combo boxes inherit the standard themed ComboBox style.
- Lets action buttons use the standard themed Button style while preserving their spacing.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable regressions were found.

The referenced brushes and implicit control styles are available before both XAML views load, and the changes follow existing theme patterns.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| extensions/pyRevitTools.extension/lib/panes/customprops/pane.py | Programmatically created headers and separators now use shared theme brushes. |
| extensions/pyRevitTools.extension/lib/panes/customprops/pane_ui.xaml | The panel now uses themed colors and standard themed control styles. |
| extensions/pyRevitTools.extension/pyRevit.tab/Analysis.panel/Tools.stack/Inspect.pulldown/Custom Properties.smartbutton/config_ui.xaml | Configuration hints and input borders now adapt to the active theme. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix dark theme for custom props panel"](https://github.com/pyrevitlabs/pyrevit/commit/f8b53c5fcde869b77e999234448b600134ac2f5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63584265)</sub>

<!-- /greptile_comment -->